### PR TITLE
Hex codes for all special characters in ES locale

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -543,8 +543,8 @@
 		},
 		es: {
 		  days: ["Domingo", "Lunes", "Martes", "Mi\xE9rcoles", "Jueves", "Viernes", "Sábado", "Domingo"],
-		  daysShort: ["Dom", "Lun", "Mar", "Mi\xE9", "Jue", "Vie", "Sáb", "Dom"],
-		  daysMin: ["Do", "Lu", "Ma", "Mi", "Ju", "Vi", "Sa", "Do"],
+		  daysShort: ["Dom", "Lun", "Mar", "Mi\xE9", "Jue", "Vie", "S\xE1b", "Dom"],
+		  daysMin: ["Do", "Lu", "Ma", "Mi", "Ju", "Vi", "S\xE1", "Do"],
 		  months: ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"],
 		  monthsShort: ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"]
 		}


### PR DESCRIPTION
Modified the remaining á characters to use HEX codes for consistency.
