### PR TITLE
Adding support for drill-down behaviour

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -126,7 +126,7 @@
 		hide: function(e){
 			this.picker.hide();
 			$(window).off('resize', this.place);
-			this.viewMode = 0;
+			this.viewMode = this.startViewMode;
 			this.showMode();
 			if (!this.isInput) {
 				$(document).off('mousedown', this.hide);


### PR DESCRIPTION
User can now pass  "start_with_decade: true" into the options hash. This will reverse the datepicker so it drills down from decade to day...

Very handy for date of birth pickers.
