### PR TITLE
Autoclose now works for datepicker component

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -48,6 +48,10 @@
 		} else {
 			if (this.component){
 				this.component.on('click', $.proxy(this.show, this));
+				var element = this.element.find('input');
+				element.on({
+					blur: $.proxy(this._hide, this)
+				})
 			} else {
 				this.element.on('click', $.proxy(this.show, this));
 			}


### PR DESCRIPTION
Autoclose was not working for datepicker component because the .blur() method was being called at the input level, and this event had no binding when the datepicker was configured as a component. I have added the binding to the input, it works with the original code now. I have chose this approach to preserve any other code associated with the hiding of the calendar.
