### PR TITLE
Added Latvian language localization for bootstrap-datepicker

### DIFF
--- a/js/locales/bootstrap-datepicker.lv.js
+++ b/js/locales/bootstrap-datepicker.lv.js
@@ -1,0 +1,15 @@
+/**
+ * Latvian translation for bootstrap-datepicker
+ * Artis Avotins <artis@apit.lv>
+ */
+
+;(function($){
+    $.fn.datepicker.dates['lv'] = {
+        days: ["Svētdiena", "Pirmdiena", "Otrdiena", "Trešdiena", "Ceturtdiena", "Piektdiena", "Sestdiena", "Svētdiena"],
+        daysShort: ["Sv", "P", "O", "T", "C", "Pk", "S", "Sv"],
+        daysMin: ["Sv", "Pr", "Ot", "Tr", "Ce", "Pk", "St", "Sv"],
+        months: ["Janvāris", "Februāris", "Marts", "Aprīlis", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"],
+        monthsShort: ["Jan", "Feb", "Mar", "Apr", "Mai", "Jūn", "Jūl", "Aug", "Sep", "Okt", "Nov", "Dec."],
+        weekStart: 1
+    };
+}(jQuery));


### PR DESCRIPTION
This commit contains a js file for Latvian language translation for bootstarp-datepicker. All shortened and minimal forms are according to official grammar specs. Also I have included the right week starting day which is Monday in Latvia.
