### PR TITLE
Added 2 new events for: picking a month + picking a year

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -370,10 +370,21 @@
 						if (!target.is('.disabled')) {
 							if (target.is('.month')) {
 								var month = target.parent().find('span').index(target);
+								this.viewDate.setDate(1);
 								this.viewDate.setMonth(month);
+								this.element.trigger({
+									type: 'pickMonth',
+									date: this.viewDate
+								});
 							} else {
 								var year = parseInt(target.text(), 10)||0;
 								this.viewDate.setFullYear(year);
+								this.viewDate.setDate(1);
+								this.viewDate.setMonth(0);
+								this.element.trigger({
+									type: 'pickYear',
+									date: this.viewDate
+								});
 							}
 							this.showMode(-1);
 							this.fill();


### PR DESCRIPTION
I've added 2 new events: 'pickMonth' and 'pickYear'. These are triggered when the user picks a month (in the year view) or year (in the decade view).

possible use case:

$('#datepicker')
.datepicker({startView:'year'})
.on('pickMonth', function(ev){
    var dateObj = new Date(ev.date.valueOf());
    var m = dateObj.getMonth()+1;
    var y = dateObj.getFullYear();
    window.location = '/calendar/'+y+'/'+m;
});

Let me know what you think! :)
