### PR TITLE
Adds keyboardNavigation option

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -63,6 +63,13 @@
 		} else if ('dateAutoclose' in this.element.data()) {
 			this.autoclose = this.element.data('date-autoclose');
 		}
+        
+        this.keyboardNavigation = true;
+        if ('keyboardNavigation' in options) {
+            this.keyboardNavigation = options.keyboardNavigation;
+        } else if ('dateKeyboardnavigation' in this.element.data()) {
+            this.keyboardNavigation = this.element.data('date-keyboardnavigation');
+        }
 
 		switch(options.startView){
 			case 2:
@@ -489,6 +496,7 @@
 					break;
 				case 37: // left
 				case 39: // right
+                    if (!this.keyboardNavigation) break;
 					dir = e.keyCode == 37 ? -1 : 1;
 					if (e.ctrlKey){
 						this.date = this.moveYear(this.date, dir);
@@ -507,6 +515,7 @@
 					break;
 				case 38: // up
 				case 40: // down
+                    if (!this.keyboardNavigation) break;
 					dir = e.keyCode == 38 ? -1 : 1;
 					if (e.ctrlKey){
 						this.date = this.moveYear(this.date, dir);


### PR DESCRIPTION
Adds keyboardNavigation option which allows users to disable the arrow key navigation of the calendar datepicker has when the input has focus.

if keyboardNavigation is true, datepicker acts as normal (the arrow keys modify the date)
if keyboardNavigation is false, the arrow keys do not modify the date
