### PR TITLE
Add Portuguese translations file to js/locales

### DIFF
--- a/js/locales/bootstrap-datepicker.pt.js
+++ b/js/locales/bootstrap-datepicker.pt.js
@@ -1,0 +1,14 @@
+/**
+ * Portuguese translation for bootstrap-datepicker
+ * Original code: Cauan Cabral <cauan@radig.com.br>
+ * Tiago Melo <tiago.blackcode@gmail.com>
+ */
+;(function($){
+	$.fn.datepicker.dates['pt'] = {
+		days: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"],
+		daysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"],
+		daysMin: ["Do", "Se", "Te", "Qu", "Qu", "Se", "Sa", "Do"],
+		months: ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
+		monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"]
+	};
+}(jQuery));


### PR DESCRIPTION
Although PT (Portuguese) translation is the same for the Brazilian translation, there should be a specific file for Portuguese. Because some web frameworks work with locales in a conventional way (like Rails), it should be straightforward to reference the locale dynamically, following the web framework's conventions. Therefore, and because Portuguese and Brazilian are somewhat different, there should be a PT translation file allow this flexibility.

I kept the translation credits similar to the Brazilian ones.
