### PR TITLE
JavaScript error if user enters punctuation symbols

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -684,7 +684,7 @@
 				}
 				return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
 			}
-			var parts = date ? date.match(this.nonpunctuation) : [],
+			var parts = date && date.match(this.nonpunctuation) || [],
 				date = new Date(),
 				parsed = {},
 				setters_order = ['yyyy', 'yy', 'M', 'MM', 'm', 'mm', 'd', 'dd'],


### PR DESCRIPTION
Start typing `-` into an `<input>` with the datepicker.

I receive `Cannot read property 'length' of null on bootstrap-datepicker.js:709`.

A simple fix is attached.
