### PR TITLE
Simple fix for error on displaying datepicker

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -622,7 +622,7 @@
 			if (!data) {
 				$this.data('datepicker', (data = new Datepicker(this, $.extend({}, $.fn.datepicker.defaults,options))));
 			}
-			if (typeof option == 'string') data[option].apply(data, args);
+			if (typeof option == 'string' && data[option]) data[option].apply(data, args);
 		});
 	};
 


### PR DESCRIPTION
I was seeing this error when attempting to display the datepicker:

```
TypeError: 'undefined' is not an object (evaluating 'data[option].apply') bootstrap-datepicker.js:626
```

This PR just fixes that.
