### PR TITLE
Putting the appended/prepended span on a new line causes spacing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Attached to a field with the format specified via data tag:
 As component:
 
     <div class="input-append date" id="datepicker" data-date="12-02-2012" data-date-format="dd-mm-yyyy">
-        <input size="16" type="text" value="12-02-2012" readonly>
-        <span class="add-on"><i class="icon-th"></i></span>
+        <input size="16" type="text" value="12-02-2012" readonly><span class="add-on"><i class="icon-th"></i></span>
     </div>
 ######
     $('#datepicker').datepicker();


### PR DESCRIPTION
It's less pretty code, but prettier UI to have it connect to the input in typical Bootstrap fashion. Having the input and span on a single line removes the space.
