### PR TITLE
fix viewDate when on input field value attribute is missing or empty, but data-date attribute is present

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -213,8 +213,8 @@
 		},
 
 		update: function(){
-            var detectedDate = (this.isInput && this.element.prop('value') !== '') ? this.element.prop('value') : this.element.data('date') || this.element.find('input').prop('value');
-			this.date = DPGlobal.parseDate(detectedDate, this.format, this.language);
+			var detectedDate = (this.isInput && this.element.prop('value') !== '') ? this.element.prop('value') : this.element.data('date') || this.element.find('input').prop('value');
+            this.date = DPGlobal.parseDate(detectedDate, this.format, this.language);
 			if (this.date < this.startDate) {
 				this.viewDate = new Date(this.startDate);
 			} else if (this.date > this.endDate) {


### PR DESCRIPTION
consider following example:

```
<input type='text' id='datepicker' data-date='02-16-2012' />
<input type='text' id='datepicker' data-date='02-16-2012' value='' />
```

in both situations $("#datepicker").datepicker() will cause to display current date as initial date.
Desired is to show date provided in date-date attribute (02-16-2012).

This commit fixes that.

Useful i.e. when asking for birthdate (when we prefer not filling upfront with some default)
After this patch is applied, it is possible to show empty input, but when user will focus he will get reasonable initial value (ie: 18 years ago, when we expect adults)

I guess this was a feature from the start, but because of subtle bug it was overlooked.
