### PR TITLE
> IE7 picker z-placement issue

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -182,7 +182,9 @@
 
 		place: function(){
 			var zIndex = parseInt(this.element.parents().filter(function() {
-							return $(this).css('z-index') != 'auto';
+							var itemZIndex = $(this).css('z-index');
+							// > ie7 incorrectly returns 0 instead of auto
+							return itemZIndex != 'auto' && itemZIndex !== 0;
 						}).first().css('z-index'))+10;
 			var offset = this.component ? this.component.offset() : this.element.offset();
 			this.picker.css({


### PR DESCRIPTION
Less than IE7 incorrectly returns 0 as the z-index of the picker's siblings when trying to place it, meaning the picker can sometimes be placed behind elements when it should be in front. For example, if the datepicker is inside a bootstrap modal, the picker will be displayed behind the modal and also behind the grey overlay.

Just added the check purely for ie.
