### PR TITLE
Build new css after the last .less changes

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -54,7 +54,6 @@
   display: block;
 }
 .datepicker table {
-  width: 100%;
   margin: 0;
 }
 .datepicker td,


### PR DESCRIPTION
So I went about fixing the problem in IE7 with the picker being really wide and totally couldn't work out why there was a random `width: 100%` on `.datepicker table`. 

Turns out `build.less' wasn't built after [Fix IE7 support](https://github.com/eternicode/bootstrap-datepicker/commit/a263e46f0fe24da4fd71739097459b353065617d) was committed.
