### PR TITLE
fix .datepicker into #datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Attached to non-field element, using events to work with the date values.
 
 Call the datepicker via javascript:
 
-    $('.datepicker').datepicker()
+    $('#datepicker').datepicker()
 
 ## Dependencies
 


### PR DESCRIPTION
In javascript example .datepicker class selector is used. Apart from being a clear leftover, this is also misleading because .datepicker class is a reserved class name for this plugin.
