### PR TITLE
Updates the value in the input on enter.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -546,6 +546,7 @@
 					}
 					break;
 				case 13: // enter
+					this.setValue();
 					this.hide();
 					e.preventDefault();
 					break;


### PR DESCRIPTION
Hi,

When navigating using keyboard only, selecting current date (i.e.. today) with keyboard does not work.

To reproduce: tab into to the date-input, calendar shows, hit enter, input is empty when current date should be set.
