### PR TITLE
Add getDate() / setDate() calls to Datepicker prototype

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -149,6 +149,24 @@
 			});
 		},
 
+		getDate: function() {
+			var d = this.getUTCDate();
+			return new Date(d.getTime() + (d.getTimezoneOffset()*60000))
+		},
+
+		getUTCDate: function() {
+			return this.date;
+		},
+
+		setDate: function(d) {
+			this.setUTCDate(new Date(d.getTime() - (d.getTimezoneOffset()*60000)));
+		},
+
+		setUTCDate: function(d) {
+			this.date = d;
+			this.setValue();
+		},
+
 		setValue: function() {
 			var formatted = DPGlobal.formatDate(this.date, this.format, this.language);
 			if (!this.isInput) {


### PR DESCRIPTION
Hi there,

In my app I'd like to access "this.date" from the Datepicker so that the actual Javascript date can be used to re-format dates for submission to the server / etc.

Usage looks something like:

```
// set a default date
$el.find(selector).data('datepicker').setDate(date);

// observe changes
$el.find(selector).change(function(e) {
    var date = $(e.target).data('datepicker').getDate();
    // do something with date
}
```

Would love to get this patch upstream.   thoughts?

cheers

-- James
