### PR TITLE
Make picker available in show and hide events.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -129,7 +129,8 @@
 			}
 			this.element.trigger({
 				type: 'show',
-				date: this.date
+				date: this.date,
+				picker: this.picker
 			});
 		},
 
@@ -145,7 +146,8 @@
 				this.setValue();
 			this.element.trigger({
 				type: 'hide',
-				date: this.date
+				date: this.date,
+				picker: this.picker
 			});
 		},
 


### PR DESCRIPTION
Now you can get to the picker without searching the DOM. Useful if you need to customise the picker on show or hide. 

We use it to scroll the screen if the picker is partially hidden.

``` javascript
$('#date').on('show', function(e) {
  var picker = e.picker;
  if (picker.isOutOfView()) {
    picker.scrollIntoView(150);
  }
});
```
