### PR TITLE
Change the source of the container height property. 

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -192,7 +192,7 @@
 						}).first().css('z-index'))+10;
 			var offset = this.component ? this.component.offset() : this.element.offset();
 			this.picker.css({
-				top: offset.top + this.height,
+				top: offset.top + this.element[0].offsetHeight,
 				left: offset.left,
 				zIndex: zIndex
 			});


### PR DESCRIPTION
Change the source of the container height property.  Popup was opening in the top of the page when Jquery ui js was included in the page. 

The property was changed from (line 195):

``` javascript
this.height 
```

to:

``` javascript
this.element[0].offsetHeight
```
