### PR TITLE
Add 'touchstart' to the closing action

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -69,7 +69,7 @@
 			}
 		}
 
-		$(document).on('mousedown', function (e) {
+		$(document).on('mousedown touchstart', function (e) {
 			// Clicked outside the datepicker, hide it
 			if ($(e.target).closest('.datepicker').length == 0) {
 				that.hide();


### PR DESCRIPTION
To support mobile devices like iPad add 'touchstart' next to 'mousedown' to close the datepicker if a user touches somewhere in the document.
