### PR TITLE
hide the datepicker once a date is selected

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -456,6 +456,7 @@
 							}
 							this._setDate(UTCDate(year, month, day,0,0,0,0));
 						}
+						this.hide();
 						break;
 				}
 			}


### PR DESCRIPTION
The fact that the date picker window remains visislbe after a date is selected by the user was kind of annoying and required the user to click somewhere outside the date selection area to get it to go away.

This change is pretty trivial and it hides the date picker after  date is selected.
