### PR TITLE
Today button (todayBtn) toggle fix.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -264,7 +264,7 @@
 						.text(dates[this.language].months[month]+' '+year);
 			this.picker.find('tfoot th.today')
 						.text(dates[this.language].today)
-						.toggle(this.todayBtn);
+						.toggle(this.todayBtn === 'linked');
 			this.updateNavArrows();
 			this.fillMonths();
 			var prevMonth = UTCDate(year, month-1, 28,0,0,0,0),


### PR DESCRIPTION
Each time a show/hide action performed in a todayBtn-enabled datepicker causes button disappear.
This is because on hide event, the display property remains table-cell instead of switching to none.

A possible fix is .toggle(this.todayBtn === 'linked') so it always be visible.
