### PR TITLE
Add component.json for better Bower compatibility

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": ["js/bootstrap-datepicker.js","css/datepicker.css"],
   "dependencies": {
-    "jquery": "~1.8.1",
-    "bootstrap": "~2.1.1"
+    "jquery" : ">=1.7.1",
+    "bootstrap" : ">=2.0.4"
   }
 }


### PR DESCRIPTION
I added the component.json file for better Bower compatibility. I wasn't sure of the version of the plugin, so I just used 1.0.0.
