### PR TITLE
Add touch support to closing action, close datepicker when different picker clicked

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -57,14 +57,6 @@
 			this.forceParse = this.element.data('date-force-parse');
 		}
 
-		$(document).on('mousedown touchstart', function (e) {
-			// Clicked outside the datepicker, hide it
-			var closest = $(e.target).closest('.datepicker');
-			if (closest.length === 0 || closest[0] !== that.element) {
-				that.hide();
-			}
-		});
-
 		this.autoclose = false;
 		if ('autoclose' in options) {
 			this.autoclose = options.autoclose;
@@ -161,6 +153,7 @@
 		},
 
 		show: function(e) {
+			var that = this;
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.update();
@@ -174,6 +167,14 @@
 				type: 'show',
 				date: this.date
 			});
+			$(document).on('mousedown.datepicker touchstart.datepicker', function (e) {
+				// Clicked outside the datepicker, hide it
+				var closest = $(e.target).closest('.datepicker');
+				if (closest.length === 0 || (closest[0] !== that.element[0] &&
+					(that.picker.length === 0 || closest[0] !== that.picker[0]))) {
+					that.hide();
+				}
+			});
 		},
 
 		hide: function(e){
@@ -181,9 +182,7 @@
 			$(window).off('resize', this.place);
 			this.viewMode = this.startViewMode;
 			this.showMode();
-			if (!this.isInput) {
-				$(document).off('mousedown', this.hide);
-			}
+			$(document).off('mousedown.datepicker touchstart.datepicker');
 
 			if (
 				this.forceParse &&


### PR DESCRIPTION
Current non-blur code leaves multiple pickers open when clicking betweeen input boxes that are all of type datepicker.
