### PR TITLE
Fix Lithuanian locale

### DIFF
--- a/js/locales/bootstrap-datepicker.lt.js
+++ b/js/locales/bootstrap-datepicker.lt.js
@@ -10,6 +10,7 @@
         daysMin: ["Sk", "Pr", "An", "Tr", "Ke", "Pn", "Št", "Sk"],
         months: ["Sausis", "Vasaris", "Kovas", "Balandis", "Gegužė", "Birželis", "Liepa", "Rugpjūtis", "Rugsėjis", "Spalis", "Lapkritis", "Gruodis"],
         monthsShort: ["Sau", "Vas", "Kov", "Bal", "Geg", "Bir", "Lie", "Rugp", "Rugs", "Spa", "Lap", "Gru"],
+        today: "Šiandien",
         weekStart: 1
     };
 }(jQuery));


### PR DESCRIPTION
Lithuanian locale is missing mandatory 'today" parameter. Without it datepicker is not loading.
