### PR TITLE
Trigger changeDate event while typing in the input

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -316,12 +316,20 @@
 
             if(fromArgs) this.setValue();
 
+			var oldViewDate = this.viewDate;
 			if (this.date < this.startDate) {
 				this.viewDate = new Date(this.startDate);
 			} else if (this.date > this.endDate) {
 				this.viewDate = new Date(this.endDate);
 			} else {
 				this.viewDate = new Date(this.date);
+			}
+
+			if (oldViewDate && oldViewDate.getTime() != this.viewDate.getTime()){
+				this.element.trigger({
+					type: 'changeDate',
+					date: this.viewDate
+				});
 			}
 			this.fill();
 		},


### PR DESCRIPTION
As title says, I added few lines to keyup event handler.
Before this change, writing date in the associated input didn't triggered the changeDate event.

Fixes #241.
