### PR TITLE
Auto-initialise datepickers on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ As component:
 $('#datepicker').datepicker();
 ```
 
+Using the `datepicker-auto` class to automatically initialise the datepicker when the page
+has finished loading:
+
+```html
+<input type="text" value="16 02 2012" class="datepicker-auto" data-date-format="dd mm yyyy">
+```
+
 Attached to non-field element, using events to work with the date values.
 
 ```html

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -960,3 +960,5 @@
 	$.fn.datepicker.DPGlobal = DPGlobal;
 
 }( window.jQuery );
+
+$(document).ready( function(){ $(".datepicker-auto").datepicker(); } );

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -12,6 +12,9 @@
 	padding: 4px;
 	margin-top: 1px;
 	.border-radius(4px);
+	&-auto {
+		/* Dummy class to allow auto-initialisation of datepicker. */
+	}
 	&-inline {
 		width: 220px;
 	}


### PR DESCRIPTION
Adds a datepicker-auto CSS class, and a line of Javascript to call the
.datepicker() method on all elements with that class when the page is
ready.
