### PR TITLE
Update js/bootstrap-datepicker.js

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -74,7 +74,7 @@
 		}
 		$(document).on('mousedown', function (e) {
 			// Clicked outside the datepicker, hide it
-			if ($(e.target).closest('.datepicker').length === 0) {
+			if ($(e.target).closest('.datepicker.datepicker-inline, .datepicker.datepicker-dropdown').length === 0) {
 				that.hide();
 			}
 		});


### PR DESCRIPTION
If programmers use the class 'datepicker' to select the elements that should have the datepicker, then under certain conditions the datepicker opens up multiple times. This patch should fix that.
