### PR TITLE
Complete `update` method with argument documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,11 @@ $('#datepicker').datepicker('hide');
 
 ### update
 
-Arguments: None
+Arguments:
 
-Update the datepicker with the current input value.
+* date (String|Date)
+
+Update the datepicker with given argument or the current input value.
 
 ```javascript
 $('#datepicker').datepicker('update');


### PR DESCRIPTION
Currently the documentation says that the `update` method doesn't take any arguments. This is untrue. The method take one argument of type **String** or **Date**.

The following block of code proves it.

``` javascript
if(arguments && arguments.length && (typeof arguments[0] === 'string' || arguments[0] instanceof Date)) {
    date = arguments[0];
    fromArgs = true;
} else {
    date = this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val();
}
```
