### PR TITLE
remove margin-top

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -9,7 +9,7 @@
  */
 .datepicker {
   padding: 4px;
-  margin-top: 1px;
+  /*margin-top: 1px;*/
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;


### PR DESCRIPTION
why need this? the margin-top will cause style problem when using  appended inputs. 
