### PR TITLE
Fire `changeDate` on <enter> in input box

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -722,6 +722,7 @@
 				case 13: // enter
 					this.hide();
 					e.preventDefault();
+                    dateChanged = true;
 					break;
 				case 9: // tab
 					this.hide();


### PR DESCRIPTION
If the user types a date into the datepicker input (#318), it would make sense for pressing `<enter>` to trigger `changeDate`, especially since it hides the calendar, leaving the user to believe that their input has been taken.

I tried writing a unit test for this, but I couldn't figure out how to test input. I'm using this patch in a project however, and it behaves as desired.
