### PR TITLE
Add support for an appended button as a target

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -41,7 +41,7 @@
 		this.format = DPGlobal.parseFormat(options.format||this.element.data('date-format')||dates[this.language].format||'mm/dd/yyyy');
 		this.isInline = false;
 		this.isInput = this.element.is('input');
-		this.component = this.element.is('.date') ? this.element.find('.add-on') : false;
+		this.component = this.element.is('.date') ? this.element.find('.add-on, .btn') : false;
 		this.hasInput = this.component && this.element.find('input').length;
 		if(this.component && this.component.length === 0)
 			this.component = false;


### PR DESCRIPTION
If you want to use a button that is appended to an input, rather than just a span, you cannot have both `btn` as well as `add-on` classes.

This change causes the component mode to attach to either a button, or a span that has been appended to an input.
