### PR TITLE
Align datepicker to input box in component mode

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -327,7 +327,7 @@
 			var zIndex = parseInt(this.element.parents().filter(function() {
 							return $(this).css('z-index') != 'auto';
 						}).first().css('z-index'))+10;
-			var offset = this.component ? this.component.offset() : this.element.offset();
+			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(true);
 			this.picker.css({
 				top: offset.top + height,


### PR DESCRIPTION
To increase the connection between the field that the datepicker is modifying, it makes sense to have the datepicker aligned with the input field, rather than the button.

It may be desirable to have this as a configurable option, but for now I kept the change as simple as possible while giving the user a much-improved experience.

This is a pull request for issue #203.
