### PR TITLE
Clicking vertical scroll does not hide datepicker

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -75,7 +75,8 @@
 		}
 		$(document).on('mousedown', function (e) {
 			// Clicked outside the datepicker, hide it
-			if ($(e.target).closest('.datepicker.datepicker-inline, .datepicker.datepicker-dropdown').length === 0) {
+			if ($(e.target).closest('.datepicker.datepicker-inline, .datepicker.datepicker-dropdown').length === 0 &&
+				e.clientX < this.body.clientWidth) {
 				that.hide();
 			}
 		});


### PR DESCRIPTION
I've been watching my users interact with the datepicker. I have it attached to an input field with autoclose turned on. When the field is near the bottom of the browser window and the user clicks on the date field this causes the datepicker to appear partially off the bottom of the browser window. They then use the vertical scrollbar to bring it into view but it disappears upon clicking the scrollbar (at least it does in IE). When it disappears the field retains focus so that clicking on the date field again does not cause the datepicker to reappear. This leaves them confused.

I suggest that clicking on the vertical scrollbar should not cause the datepicker to hide itself. This change fixes that.

This change also causes the test 'Clicking outside datepicker hides datepicker' to fail. I'm not sure why it fails or how to fix it. I also do not understand the test architecture enough to add a test for this change in functionality. Sorry about that.

Thanks, -- Jim
