### PR TITLE
fix language definition for rs-latin

### DIFF
--- a/js/locales/bootstrap-datepicker.rs-latin.js
+++ b/js/locales/bootstrap-datepicker.rs-latin.js
@@ -3,7 +3,7 @@
  * Bojan Milosavlević <milboj@gmail.com>
  */
 ;(function($){
-	$.fn.datepicker.dates['rs'] = {
+	$.fn.datepicker.dates['rs-latin'] = {
 		days: ["Nedelja","Ponedeljak", "Utorak", "Sreda", "Četvrtak", "Petak", "Subota", "Nedelja"],
 		daysShort: ["Ned", "Pon", "Uto", "Sre", "Čet", "Pet", "Sub", "Ned"],
 		daysMin: ["N", "Po", "U", "Sr", "Č", "Pe", "Su", "N"],


### PR DESCRIPTION
I tried to include both rs and rs-latin locale and found out that the language definition was the same for both _bootstrap-datepicker.rs.js_ and _bootstrap-datepicker.rs-latin.js_ scripts.
This commit corrects the language definition in the rs-latin.js script.
