### PR TITLE
Fixing Today + Active = black text on blue background

### DIFF
--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -98,7 +98,7 @@
 		&.today.disabled:hover {
 			@todayBackground: lighten(@orange, 30%);
 			.buttonBackground(@todayBackground, spin(@todayBackground, 20));
-			color: #000 !important;
+			color: #000;
 		}
 		&.active,
 		&.active:hover,


### PR DESCRIPTION
If todayHighlight == true and the active day in the calendar is today, the text remains black, despite the background being a dark blue (unreadable). I tracked it down to the !important declaration on the style definition for td.today. Removing !important doesn't seem to have any side effects in tested browsers: Chrome 25.0.1364.152 m and IE7-10.
