### PR TITLE
Fix formatter. The end of the format string disappears.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -985,6 +985,8 @@
 					date.push(seps.shift());
 				date.push(val[format.parts[i]]);
 			}
+			if (seps.length)
+				date.push(seps.shift());
 			return date.join('');
 		},
 		headTemplate: '<thead>'+

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -112,6 +112,14 @@ test('yyyy-mm-dd: Alternative format', function(){
     equal(this.input.val(), '2012-02-12');
 });
 
+test('[yyyy-mm-dd]: head literal and tail literal.', function(){
+    this.input
+        .val('2012-02-12')
+        .datepicker({format: '[yyyy-mm-dd]'})
+        .datepicker('setValue');
+    equal(this.input.val(), '[2012-02-12]');
+});
+
 test('yyyy-MM-dd: Regression: Infinite loop when numbers used for month', function(){
     this.input
         .val('2012-02-12')


### PR DESCRIPTION
The formatter losts strings after the last format keyword.

```
format: 'pre[ yyyy/mm ]post'
```

outputs

```
pre[ 2013/03
```
