### PR TITLE
Bind to events only when the picker is shown. (fixes a memory leak)

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -55,12 +55,7 @@
 			this.forceParse = this.element.data('date-force-parse');
 		}
 
-
-		this.picker = $(DPGlobal.template)
-							.on({
-								click: $.proxy(this.click, this),
-								mousedown: $.proxy(this.mousedown, this)
-							});
+		this.picker = $(DPGlobal.template);
 
 		if(this.isInline) {
 			this.picker.addClass('datepicker-inline').appendTo(this.element);
@@ -72,12 +67,6 @@
 			this.picker.find('.prev i, .next i')
 						.toggleClass('icon-arrow-left icon-arrow-right');
 		}
-		$(document).on('mousedown', function (e) {
-			// Clicked outside the datepicker, hide it
-			if ($(e.target).closest('.datepicker.datepicker-inline, .datepicker.datepicker-dropdown').length === 0) {
-				that.hide();
-			}
-		});
 
 		this.autoclose = false;
 		if ('autoclose' in options) {
@@ -212,6 +201,12 @@
 			}
 			this._events = [];
 		},
+		_documentMousedown: function (e) {
+			// Clicked outside the datepicker, hide it
+			if ($(e.target).closest('.datepicker.datepicker-inline, .datepicker.datepicker-dropdown').length === 0) {
+				this.hide();
+			}
+		},
 
 		show: function(e) {
 			if (!this.isInline)
@@ -219,7 +214,9 @@
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.place();
-			$(window).on('resize', $.proxy(this.place, this));
+			this.picker.on('click.picker', $.proxy(this.click, this));
+			$(window).on('resize.picker', $.proxy(this.place, this));
+			$(document).on('mousedown.picker', $.proxy(this._documentMousedown, this));
 			if (e) {
 				e.preventDefault();
 			}
@@ -233,12 +230,11 @@
 			if(this.isInline) return;
 			if (!this.picker.is(':visible')) return;
 			this.picker.hide().detach();
-			$(window).off('resize', this.place);
+			this.picker.off('click.picker');
+			$(window).off('resize.picker');
+			$(document).off('mousedown.picker');
 			this.viewMode = this.startViewMode;
 			this.showMode();
-			if (!this.isInput) {
-				$(document).off('mousedown', this.hide);
-			}
 
 			if (
 				this.forceParse &&
@@ -255,6 +251,7 @@
 		},
 
 		remove: function() {
+			this.hide();
 			this._detachEvents();
 			this.picker.remove();
 			delete this.element.data().datepicker;


### PR DESCRIPTION
Right now the datepicker ALWAYS binds to the document mousedown event upon initialization and never unbinds from it, even when 'remove' method is called.

This creates a nasty memory leak if one is creating/removing datepickers which is the case with any single page application using it(mine included).

I've also noticed that on slow computers with IE8 having 10+ datepickers on a single page makes the page unusable as on every click those 10+ mousedown handlers are executed traversing the DOM looking for the closest datepicker.

I've changed the event binding/unbinding for the document and picker events to be done on show/hide so that those events are listened to only when needed.

I've also scoped the events with the '.picker' namespace to ease unbinding.

Thanks!
