### PR TITLE
fixing broken setDate

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -273,7 +273,7 @@
 		},
 
 		setDate: function(d) {
-			this.setUTCDate(new Date(d.getTime() - (d.getTimezoneOffset()*60000)));
+			this.setUTCDate(new Date(d.getTime()));
 		},
 
 		setUTCDate: function(d) {


### PR DESCRIPTION
Set date was adding the timezone back to a UTC timestamp before calling setUTCDate. Need to confirm that all JS imlementations return UTC for Date.getTime(), however, that's what the spec says and what Chrome currently does.
