### PR TITLE
Fix for issue #372

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -372,7 +372,7 @@
 				date = arguments[0];
 				fromArgs = true;
 			} else {
-				date = this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val();
+				date = this.isInput ? this.element.val() : this.element.find('input').val() || this.element.data('date');
 			}
 
 			this.date = DPGlobal.parseDate(date, this.format, this.language);


### PR DESCRIPTION
I found that the update function fetches the new date value from different sources on line 375.
These prioritized order is:
 1: this.element.val()
 2: this.element.data('date')
 3: this.element.find('input').val()

The fix involed swapping 2 and 3 around so the new value is fetches from the input field before its data property.
I have not had time to investigate the full consequence of this change, but all the qunit tests still pass and my own limited user test showed that the plugin behaves as expected.
