### PR TITLE
Fix Finnish week start to Monday, add format

### DIFF
--- a/js/locales/bootstrap-datepicker.fi.js
+++ b/js/locales/bootstrap-datepicker.fi.js
@@ -9,6 +9,8 @@
 		daysMin: ["su", "ma", "ti", "ke", "to", "pe", "la", "su"],
 		months: ["tammikuu", "helmikuu", "maaliskuu", "huhtikuu", "toukokuu", "kesäkuu", "heinäkuu", "elokuu", "syyskuu", "lokakuu", "marraskuu", "joulukuu"],
 		monthsShort: ["tam", "hel", "maa", "huh", "tou", "kes", "hei", "elo", "syy", "lok", "mar", "jou"],
-		today: "tänään"
+		today: "tänään",
+		weekStart: 1,
+		format: "d.m.yyyy"
 	};
 }(jQuery));


### PR DESCRIPTION
Finns _always_ start their week on Mondays.

The d.m.yyyy date format is the most common one.
