### PR TITLE
remove redundant call to setValue

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -265,7 +265,6 @@
 					this.hasInput && this.element.find('input').val()
 				)
 			)
-				this.setValue();
 			this.element.trigger({
 				type: 'hide',
 				date: this.date


### PR DESCRIPTION
The behavior I wanted to create for my date picker was that the user could type a date _or_ use the date picker to choose a date. If you disable the date picker's keyboard selection, this _almost_ works great.

However, when you type a date, then tab or click out of the input element, the date picker's hide() method is called, which _always_ calls setValue(), which always overwrites the input value with the date picker's stored value. This makes it impossible to set the value without using the date picker.

The simple solution that seems to be working for me was to remove the setValue() call from hide(). This allows the date picker to disappear as it should without overwriting the input value.

The potential problem with this is that other parts of the date picker _may_ be relying on this setValue() call within hide() to update the input (for example, when a date is clicked or the keyboard is used to navigate through the calendar). Inspecting those parts of the code indicate, however, that they already call setValue() themselves, so this setValue() call within hide() is not needed for those interactions. As far as I can tell the date is still properly updated when the calendar is clicked or the keyboard is used.

Maybe there are other cases where this setValue() call is necessary that I don't know about?
