### PR TITLE
Allowing user to manually input date

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -381,6 +381,7 @@
 
 			if(fromArgs) this.setValue();
 
+			var oldViewDate = this.viewDate;
 			if (this.date < this.startDate) {
 				this.viewDate = new Date(this.startDate);
 			} else if (this.date > this.endDate) {
@@ -388,6 +389,13 @@
 			} else {
 				this.viewDate = new Date(this.date);
 			}
+			
+			if (oldViewDate && oldViewDate.getTime() != this.viewDate.getTime()) {
+                this.element.trigger({
+                    type: 'changeDate',
+                    date: this.viewDate
+                });
+            }
 			this.fill();
 		},
 


### PR DESCRIPTION
This allows the date to be set from the user manually inputing the date
into the input box. This had been discussed previously in an issue and was somewhat answered on a side note. The change is actually from another fork, but had never been actually a pull request. Recently we had used this feature and it worked wonderfully for the purpose we had in mind.

Here is the previous issue that was involved with this.

[Issue #165](https://github.com/eternicode/bootstrap-datepicker/issues/165)
