### PR TITLE
Fix missing weight parameter in mix() in datepicker.less

### DIFF
--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -111,7 +111,7 @@
 		&.range.today:hover,
 		&.range.today.disabled,
 		&.range.today.disabled:hover {
-			@todayBackground: mix(@orange, @grayLighter);
+			@todayBackground: mix(@orange, @grayLighter, 50%);
 			.buttonBackground(@todayBackground, spin(@todayBackground, 20));
 			.border-radius(0);
 		}


### PR DESCRIPTION
Added missing weight parameter to mix() in datepicker.less. This was stopping causing compile errors when running lessphp.

The value has been set to 50%.
