### PR TITLE
Added Turkish date format.

### DIFF
--- a/js/locales/bootstrap-datepicker.tr.js
+++ b/js/locales/bootstrap-datepicker.tr.js
@@ -9,7 +9,8 @@
 		daysMin: ["Pz", "Pzt", "Sa", "Çr", "Pr", "Cu", "Ct", "Pz"],
 		months: ["Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"],
 		monthsShort: ["Oca", "Şub", "Mar", "Nis", "May", "Haz", "Tem", "Ağu", "Eyl", "Eki", "Kas", "Ara"],
-		today: "Bugün"
+		today: "Bugün",
+		format: "dd.mm.yyyy"
 	};
 }(jQuery));
 

--- a/tests/suites/language.js
+++ b/tests/suites/language.js
@@ -1,0 +1,30 @@
+module('Language', {
+    setup: function(){
+        this.input = $('<input type="text">').appendTo('#qunit-fixture');
+        this.date = UTCDate(2012, 2, 15, 0, 0, 0, 0); // March 15, 2012
+    },
+    teardown: function(){
+        this.input.data('datepicker').picker.remove();
+    }
+});
+
+test('language-default: Default language format.', function(){
+    this.input
+        .val('03/16/2012')
+        .datepicker();
+    equal(this.input.val(), '03/16/2012');
+});
+
+test('language-it: Italian language format.', function(){
+    this.input
+        .val('16/03/2012')
+        .datepicker();
+    equal(this.input.val(), '16/03/2012');
+});
+
+test('language-tr: Turkish language format.', function(){
+    this.input
+        .val('16.03.2012')
+        .datepicker({language: 'tr'});
+    equal(this.input.val(), '16.03.2012');
+});

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -36,6 +36,7 @@
         <script src="suites/inline.js"></script>
         <script src="suites/calendar-weeks.js"></script>
         <script src="suites/data-api.js"></script>
+        <script src="suites/language.js"></script>
     </head>
     <body>
         <h1 id="qunit-header">bootstrap-datepicker</h1>


### PR DESCRIPTION
The Turkish date format is not specified, as [it should be](http://en.wikipedia.org/wiki/Date_and_time_notation_in_Turkey) `dd.mm.yyyy`.

I have also added a new test module which is used for testing date formats. As of now, it only tests against `it` and `tr` formats.
