### PR TITLE
Clear Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Boolean.  Default: false
 
 If true, highlights the current date.
 
+### clearBtn
+
+Boolean.  Default: false
+
+If true, displays a "Clear" button at the bottom of the datepicker to clear the input value. If "autoclose" is also set to true, this button will also close the datepicker.
+
 ### keyboardNavigation
 
 Boolean.  Default: true

--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -387,11 +387,11 @@
   width: 145px;
 }
 .datepicker thead tr:first-child th,
-.datepicker tfoot tr:first-child th {
+.datepicker tfoot tr th {
   cursor: pointer;
 }
 .datepicker thead tr:first-child th:hover,
-.datepicker tfoot tr:first-child th:hover {
+.datepicker tfoot tr th:hover {
   background: #eeeeee;
 }
 .datepicker .cw {

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -114,6 +114,8 @@
 		this.todayBtn = (options.todayBtn||this.element.data('date-today-btn')||false);
 		this.todayHighlight = (options.todayHighlight||this.element.data('date-today-highlight')||false);
 
+        this.clearBtn = (options.clearBtn||false);
+
 		this.calendarWeeks = false;
 		if ('calendarWeeks' in options) {
 			this.calendarWeeks = options.calendarWeeks;
@@ -474,6 +476,9 @@
 			this.picker.find('tfoot th.today')
 						.text(dates[this.language].today)
 						.toggle(this.todayBtn !== false);
+            this.picker.find('tfoot th.clear')
+                        .text(dates[this.language].clear)
+                        .toggle(this.clearBtn !== false);
 			this.updateNavArrows();
 			this.fillMonths();
 			var prevMonth = UTCDate(year, month-1, 28,0,0,0,0),
@@ -631,6 +636,11 @@
 								var which = this.todayBtn == 'linked' ? null : 'view';
 								this._setDate(date, which);
 								break;
+                            case 'clear':
+                                this.element.val("");
+                                if (this.autoclose)
+                                    this.hide();
+                                break;
 						}
 						break;
 					case 'span':
@@ -958,7 +968,8 @@
 			daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
 			months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
 			monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-			today: "Today"
+			today: "Today",
+            clear: "Clear"
 		}
 	};
 
@@ -1118,7 +1129,7 @@
 							'</tr>'+
 						'</thead>',
 		contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',
-		footTemplate: '<tfoot><tr><th colspan="7" class="today"></th></tr></tfoot>'
+		footTemplate: '<tfoot><tr><th colspan="7" class="today"></th></tr><tr><th colspan="7" class="clear"></th></tr></tfoot>'
 	};
 	DPGlobal.template = '<div class="datepicker">'+
 							'<div class="datepicker-days">'+

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -168,7 +168,7 @@
 	}
 
 	thead tr:first-child th,
-	tfoot tr:first-child th {
+	tfoot tr th {
 		cursor: pointer;
 		&:hover{
 			background: @grayLighter;

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -262,6 +262,79 @@ test('Today Highlight: today\'s date is highlighted when not active', patch_date
         ok(!target.hasClass('today'), 'Tomorrow is not marked with "today" class');
 }));
 
+test('Clear Button: clear visibility when enabled', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    clearBtn: true
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        input.focus();
+        ok(picker.find('.datepicker-days').is(':visible'), 'Days view visible');
+        ok(picker.find('.datepicker-days tfoot .clear').is(':visible'), 'Clear button visible');
+
+        picker.find('.datepicker-days thead th.datepicker-switch').click();
+        ok(picker.find('.datepicker-months').is(':visible'), 'Months view visible');
+        ok(picker.find('.datepicker-months tfoot .clear').is(':visible'), 'Clear button visible');
+
+        picker.find('.datepicker-months thead th.datepicker-switch').click();
+        ok(picker.find('.datepicker-years').is(':visible'), 'Years view visible');
+        ok(picker.find('.datepicker-years tfoot .clear').is(':visible'), 'Clear button visible');
+});
+
+test('Clear Button: clears input value', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    clearBtn: true
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        input.focus();
+        ok(picker.find('.datepicker-days').is(':visible'), 'Days view visible');
+        ok(picker.find('.datepicker-days tfoot .clear').is(':visible'), 'Today button visible');
+
+        target = picker.find('.datepicker-days tfoot .clear');
+        target.click();
+
+        equal(input.val(),'',"Input value has been cleared.")
+        ok(picker.is(':visible'), 'Picker is visible');
+});
+
+test('Clear Button: hides datepicker if autoclose is on', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    clearBtn: true,
+                    autoclose: true
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+        input.focus();
+        ok(picker.find('.datepicker-days').is(':visible'), 'Days view visible');
+        ok(picker.find('.datepicker-days tfoot .clear').is(':visible'), 'Today button visible');
+
+        target = picker.find('.datepicker-days tfoot .clear');
+        target.click();
+
+        equal(input.val(),'',"Input value has been cleared.");
+        ok(picker.is(':not(:visible)'), 'Picker is hidden');
+
+});
+
 test('DaysOfWeekDisabled', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')


### PR DESCRIPTION
Adds an optional Clear button below the Today button. Clicking it clears the input field, and if the autofocus option is set to true, also closes the datepicker.
