### PR TITLE
Bug fix for date not being constrained between startDate and endDate

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -383,10 +383,13 @@
 
 			if (this.date < this.startDate) {
 				this.viewDate = new Date(this.startDate);
+				this.date = new Date(this.startDate);
 			} else if (this.date > this.endDate) {
 				this.viewDate = new Date(this.endDate);
+				this.date = new Date(this.endDate);
 			} else {
 				this.viewDate = new Date(this.date);
+				this.date = new Date(this.date);
 			}
 			this.fill();
 		},

--- a/tests/suites/component.js
+++ b/tests/suites/component.js
@@ -177,3 +177,17 @@ test('Does not block events', function(){
     equal(clicks, 1);
     $('#qunit-fixture').off('click', '.add-on', handler);
 });
+
+test('date and viewDate must be between startDate and endDate when setStartDate called', function() {
+    this.dp.setDate(UTCDate(2013, 1, 1));
+    this.dp.setStartDate(UTCDate(2013, 5, 6));
+    datesEqual(this.dp.viewDate, UTCDate(2013, 5, 6));
+    datesEqual(this.dp.date, UTCDate(2013, 5, 6));
+});
+
+test('date and viewDate must be between startDate and endDate when setEndDate called', function() {
+    this.dp.setDate(UTCDate(2013, 12, 1));
+    this.dp.setEndDate(UTCDate(2013, 5, 6));
+    datesEqual(this.dp.viewDate, UTCDate(2013, 5, 6));
+    datesEqual(this.dp.date, UTCDate(2013, 5, 6));
+});


### PR DESCRIPTION
Fixed the issue where date was not being constrained between startDate and endDate by setting date in update() in the same manner in which viewDate is set.

Added tests. All are passing.
