### PR TITLE
Add: New event for calendar redraw/fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,10 @@ Fired when the *view* year is changed from decade view.
 
 Fired when the *view* month is changed from year view.
 
+### fill
+
+Fired every time the datepicker is redrawn.
+
 ## Keyboard support
 
 The datepicker includes some keyboard navigation:

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -563,6 +563,7 @@
 				year += 1;
 			}
 			yearCont.html(html);
+			this._trigger('fill');
 		},
 
 		updateNavArrows: function() {

--- a/tests/suites/events.js
+++ b/tests/suites/events.js
@@ -159,3 +159,26 @@ test('Clear button: triggers change and changeDate events', function(){
     equal(triggered_change, 1);
     equal(triggered_changeDate, 1);
 });
+
+test('Fill method: Triggers fill event', function () {
+    this.input = $('<input type="text" value="31-03-2011">')
+                    .appendTo('#qunit-fixture')
+                    .datepicker({
+                        format: "dd-mm-yyyy",
+                        clearBtn: true
+                    })
+                    .focus(); // Activate for visibility checks
+
+    this.dp = this.input.data('datepicker');
+    this.picker = this.dp.picker;
+
+    var triggered = false;
+
+    this.input.on('fill', function (event) {
+        triggered = true;
+    });
+
+    this.dp.fill();
+
+    equal(triggered, true);
+});


### PR DESCRIPTION
Included a new event `onFill` for whenever the fill method is called.

This is useful for hooking into the calendar draw process to attach
custom classes or functionality that might need to be re-attached every
time the calendar is redrawn.
