### PR TITLE
Added test cases for the exposed API.

### DIFF
--- a/tests/suites/methods.js
+++ b/tests/suites/methods.js
@@ -1,0 +1,63 @@
+module('Methods', {
+    setup: function(){
+        this.input = $('<input type="text" value="31-03-2011">')
+                        .appendTo('#qunit-fixture')
+                        .datepicker({format: "dd-mm-yyyy"});
+        this.dp = this.input.data('datepicker')
+    },
+    teardown: function(){
+        this.dp.remove();
+    }
+});
+
+// test('remove', function(){
+    
+// });
+
+// test('show', function(){
+    
+// });
+
+// test('hide', function(){
+    
+// });
+
+// test('update - String', function(){
+    
+// });
+
+// test('update - Date', function(){
+    
+// });
+
+test('setDate', function(){
+    var dateToSet = new Date(2013,01,01,12,00,00,00);
+    
+    notEqual(this.dp.date,dateToSet);
+    this.dp.setDate(dateToSet);
+    datesEqual(this.dp.date.getTime(),dateToSet.getTime());
+});
+
+test('setUTCDate', function(){
+    var dateToSet = Date.UTC(2012,3,5);
+
+    notEqual(this.dp.date,dateToSet);
+    this.dp.setUTCDate(dateToSet);
+    datesEqual(this.dp.date,dateToSet);
+});
+
+// test('setStartDate', function(){
+
+// });
+
+// test('setEndDate', function(){
+
+// });
+
+// test('setDaysOfWeekDisabled - String', function(){
+
+// });
+
+// test('setDaysOfWeekDisabled - Array', function(){
+
+// });

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -36,6 +36,7 @@
         <script src="suites/inline.js"></script>
         <script src="suites/calendar-weeks.js"></script>
         <script src="suites/data-api.js"></script>
+        <script src="suites/methods.js"></script>
     </head>
     <body>
         <h1 id="qunit-header">bootstrap-datepicker</h1>


### PR DESCRIPTION
I think having test cases for the **public API** makes sense. Especially since these tests are currently failing. I know the calendar is using UTC in the back, but it becomes very hard to use when this simple test case fails.

Should we build an auto-translate? I don't know what the best solution might be right now. But I do think that **whatever the user passes to setDate** is what should be returned by the calendar object on getDate. Makes sense?

**NOTE**: The only active tests are setDate and setUTCDate for now, since I didn't want everything to explode. All public methods are _typed_ just need to un-comment them when ready to build the test.
