### PR TITLE
Made startDate and endDate default to -Infinity and Infinity for false values

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -139,18 +139,18 @@
 
 			var format = DPGlobal.parseFormat(o.format);
 			if (o.startDate !== -Infinity) {
-                if (!!o.startDate) {
-				    o.startDate = DPGlobal.parseDate(o.startDate, format, o.language);
-                } else {
-                    o.startDate = -Infinity;
-                }
+				if (!!o.startDate) {
+					o.startDate = DPGlobal.parseDate(o.startDate, format, o.language);
+				} else {
+					o.startDate = -Infinity;
+				}
 			}
 			if (o.endDate !== Infinity) {
-                if (!!o.endDate) {
-				    o.endDate = DPGlobal.parseDate(o.endDate, format, o.language);
-                } else {
-                    o.endDate = Infinity;
-                }
+				if (!!o.endDate) {
+					o.endDate = DPGlobal.parseDate(o.endDate, format, o.language);
+				} else {
+					o.endDate = Infinity;
+				}
 			}
 
 			o.daysOfWeekDisabled = o.daysOfWeekDisabled||[];


### PR DESCRIPTION
Added logic to the _process_options function so that values of startDate and endDate that resolve to false (such as an empty string) will default to -Infinity or Infinity, respectively, rather than throwing an error.

Added a missing semi-colon.
