### PR TITLE
Prevent text selection

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -66,6 +66,12 @@
 }
 .datepicker table {
   margin: 0;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 .datepicker td,
 .datepicker th {


### PR DESCRIPTION
Prevented text selection in calendar using:

-webkit-touch-callout: none;
-webkit-user-select: none;
-khtml-user-select: none;
-moz-user-select: none;
-ms-user-select: none;
user-select: none;
