### PR TITLE
Re-added Turkish date format

### DIFF
--- a/js/locales/bootstrap-datepicker.tr.js
+++ b/js/locales/bootstrap-datepicker.tr.js
@@ -9,7 +9,8 @@
 		daysMin: ["Pz", "Pzt", "Sa", "Çr", "Pr", "Cu", "Ct", "Pz"],
 		months: ["Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"],
 		monthsShort: ["Oca", "Şub", "Mar", "Nis", "May", "Haz", "Tem", "Ağu", "Eyl", "Eki", "Kas", "Ara"],
-		today: "Bugün"
+		today: "Bugün",
+		format: "dd.mm.yyyy"
 	};
 }(jQuery));
 


### PR DESCRIPTION
The Turkish date format is not specified, as [it should be](http://en.wikipedia.org/wiki/Date_and_time_notation_in_Turkey) `dd.mm.yyyy`.

This is the original #449 split as requested.
