### PR TITLE
Support external changes to the date value

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -317,6 +317,9 @@
 				if (this.component){
 					this.element.find('input').val(formatted);
 				}
+				else {
+					this.element.attr('data-date', formatted);
+				}
 			} else {
 				this.element.val(formatted);
 			}


### PR DESCRIPTION
To be able to support external changes to the value, `this.update()` should be called every time the datepicker is shown. In addition, there is a difference between jquery's `data('date')` or `data().date` and `attr('data-date')`. The former caches the value retrieved from the element, while the latter pulls from the element every time, which allows external frameworks to update the value. [See here](http://forum.jquery.com/topic/jquery-data-caching-of-data-attributes)

I ran into these issues while using Backbone.Stickit to update values in the html
