### PR TITLE
z-value added

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -13,6 +13,7 @@
   -moz-border-radius: 4px;
   border-radius: 4px;
   direction: ltr;
+  z-index:9999;
   /*.dow {
 		border-top: 1px solid #ddd !important;
 	}*/


### PR DESCRIPTION
I was using datepicker in a modal, and the lack of a z-value caused it to appear behind the modal.
