### PR TITLE
Allow the space bar to toggle the picker show/hide

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -772,9 +772,10 @@
 
 		keydown: function(e){
 			if (this.picker.is(':not(:visible)')){
-				if (e.keyCode == 27 || e.keyCode == 32) // allow escape or space to hide and re-show picker
+				if (e.keyCode == 27 || e.keyCode == 32){ // allow escape or space to hide and re-show picker
 					this.show();
 					e.preventDefault();
+				}
 				return;
 			}
 			var dateChanged = false,


### PR DESCRIPTION
Our application using the datepicker is currently undergoing an accessibility review.  One easily fixable item is to add support for the space bar to toggle the picker show/hide.  See http://access.aol.com/dhtml-style-guide-working-group/#datepicker for more info.
