### PR TITLE
adding timezoneoffset in _setDate()

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -788,7 +788,7 @@
 									month += 1;
 								}
 							}
-							this._setDate(UTCDate(year, month, day,0,0,0,0));
+							this._setDate(UTCDate(year, month, day, 0, 0, 0, 0));
 						}
 						break;
 				}
@@ -797,9 +797,9 @@
 
 		_setDate: function(date, which){
 			if (!which || which == 'date')
-				this.date = new Date(date);
+				this.date = new Date(date + (date.getTimezoneOffset()*60000));
 			if (!which || which  == 'view')
-				this.viewDate = new Date(date);
+				this.viewDate = new Date(date + (date.getTimezoneOffset()*60000));
 			this.fill();
 			this.setValue();
 			this._trigger('changeDate');


### PR DESCRIPTION
Adding timezone offset in _setDate to prevent selections being off by 1 day as per issue https://github.com/eternicode/bootstrap-datepicker/issues/544 
