### PR TITLE
Added a headerRtl option, to enable custom header behaviour

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -21,9 +21,6 @@
 .datepicker-inline {
   width: 220px;
 }
-.datepicker thead.datepicker-rtl {
-  direction: rtl;
-}
 .datepicker tbody.datepicker-rtl tr td span {
   float: right;
 }

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -57,9 +57,8 @@
 		}
 
 		if (this.o.headerRtl){
-			this.picker.find("thead").addClass('datepicker-rtl');
-			this.picker.find('.prev i, .next i')
-						.toggleClass('icon-arrow-left icon-arrow-right');
+			this.picker.find('.prev, .next')
+						.toggleClass('next prev');
 		}
 
 		if (this.o.rtl){

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -15,9 +15,6 @@
 		width: 220px;
 	}
 	direction: ltr;
-	thead.datepicker-rtl {
-		direction: rtl;
-	}
 	tbody.datepicker-rtl
 		tr td span {
 			float: right;

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -502,8 +502,8 @@ test('Right to Left: values are parsed correctly', function(){
     equal(dp.o.rtl, true, '"Calendar Right to Left Option Parsed"');
     equal(dp.o.headerRtl, true, '"Header Right to Left Option Parsed"');
 
-    target = picker.find('thead');
-    ok(target.hasClass('datepicker-rtl'), '"Header is right to left"');
+    target = picker.find('thead th:last');
+    ok(target.hasClass('prev'), '"Header is right to left"');
 
     target = picker.find('tbody');
     ok(target.hasClass('datepicker-rtl'), '"Calendar is right to left"');


### PR DESCRIPTION
I've added a headerRtl, to allow the pickers header rtl value to set set independently of the calendar days. This satisfies #549.
