### PR TITLE
Update bootstrap-datepicker.js

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -445,7 +445,7 @@
 			if (yorient === 'top')
 				top += height;
 			else
-				top -= calendarHeight + parseInt(this.picker.css('padding'));
+				top -= calendarHeight + parseInt(this.picker.css('padding-top'));
 
 			this.picker.css({
 				top: top,


### PR DESCRIPTION
The property padding doesn't work on Firefox or Internet explorer.
