### PR TITLE
Fix setDate not updating the UI when settingDate on different Month

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -800,6 +800,8 @@
 				this.date = new Date(date);
 			if (!which || which  == 'view')
 				this.viewDate = new Date(date);
+			else
+				this.viewDate = this.date;
 			this.fill();
 			this.setValue();
 			this._trigger('changeDate');


### PR DESCRIPTION
When using setDate for a month currently not visible, the highlight box will aparently move, but not the visible month. for now I have tracked the problem down to the `this.viewDate` not being updated before calling the `this.fill()` method.

This PR fixes issue #399 
