### PR TITLE
Corrected position bug

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -444,8 +444,15 @@
 			this.picker.addClass('datepicker-orient-' + yorient);
 			if (yorient === 'top')
 				top += height;
-			else
-				top -= calendarHeight + parseInt(this.picker.css('padding'));
+			else {
+				var pickerPadding = parseInt(this.picker.css('padding'));
+
+				if (isNaN(pickerPadding)) {
+					pickerPadding = 0;
+				}
+
+				top -= calendarHeight + pickerPadding;
+			}
 
 			this.picker.css({
 				top: top,


### PR DESCRIPTION
I was using this with a Bootstrap theme (http://bootswatch.com/flatly/) and realized that in the modified snippet, this.picker.css('padding') ended up being NaN, hence messing the picker's position up.

I simply added a quick check to avoid this and use 0 as a default value if no integer can be parsed out of the picker's padding.
