### PR TITLE
Trigger changeDate event when manually updating the field.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -469,7 +469,13 @@
 
 			this.date = DPGlobal.parseDate(date, this.o.format, this.o.language);
 
-			if(fromArgs) this.setValue();
+			if (fromArgs) { // setting date by clicking
+                   	  this.setValue()
+                   	} else if (date) { // setting date by typing
+                   	  this._trigger('changeDate');
+                   	} else { // clearing date by typing
+                   	  this._trigger('clearDate');
+                   	};
 
 			if (this.date < this.o.startDate) {
 				this.viewDate = new Date(this.o.startDate);


### PR DESCRIPTION
Also adds `clearDate` event when the field is manually cleared.  The reason for two separate events is because by design, the Datepicker's date cannot be set to null.

Let me know what you all think. Fixes #517, #488.
