### PR TITLE
Make it work with Bootstrap 3.0

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -41,7 +41,7 @@
 		this.element = $(element);
 		this.isInline = false;
 		this.isInput = this.element.is('input');
-		this.component = this.element.is('.date') ? this.element.find('.add-on, .btn') : false;
+		this.component = this.element.is('.date') ? this.element.find('.add-on, .btn, .input-group-addon') : false;
 		this.hasInput = this.component && this.element.find('input').length;
 		if(this.component && this.component.length === 0)
 			this.component = false;


### PR DESCRIPTION
Small fix to make it work out of the box with Bootstrap 3.0 :) Essentially only add the new addon class that comes with Bootstrap 3.0. Works like a charm afterward.
