### PR TITLE
Update active day logic to compare only date

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -556,9 +556,9 @@
 				cls.push('today');
 			}
 			if (currentDate &&
-				date.getUTCFullYear() == currentDate.getFullYear() &&
-				date.getUTCMonth() == currentDate.getMonth() &&
-				date.getUTCDate() == currentDate.getDate()) {
+				date.getFullYear() == currentDate.getFullYear() &&
+				date.getMonth() == currentDate.getMonth() &&
+				date.getDate() == currentDate.getDate()) {
 				cls.push('active');
 			}
 			if (date.valueOf() < this.o.startDate || date.valueOf() > this.o.endDate ||


### PR DESCRIPTION
When setting the active class on a day cell, the comparison should only compare date values and not time values as well.  This way if someone sets the date to 8/7/2013 6:30 AM, it will still highlight 8/7/2013 as the active day.
