### PR TITLE
Don't reset selected date when the element is a button.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -485,7 +485,7 @@
 					date = this._local_to_utc(date);
 				fromArgs = true;
 			} else {
-				date = this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val();
+				date = this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val() || this.element.text();
 				delete this.element.data().date;
 			}
 


### PR DESCRIPTION
If the element is not an input, the selected date changes to 'today' on
update event as the input val() is undefined. This commit adds  `this.element.text()` as an alternative to
input val() method.
