### PR TITLE
Fixed a z-index issue while inside modals

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -419,7 +419,8 @@
 				scrollTop = $window.scrollTop();
 
 			var zIndex = parseInt(this.element.parents().filter(function() {
-							return $(this).css('z-index') != 'auto';
+							var zIndex = $(this).css('z-index');
+							return zIndex != 'auto' && zIndex != '0';
 						}).first().css('z-index'))+10;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);


### PR DESCRIPTION
The parents cycle took the parent with z-index = '0', breaking everything
