### PR TITLE
Fixing in bootstrap-modal appereance.

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -13,6 +13,7 @@
   -moz-border-radius: 4px;
   border-radius: 4px;
   direction: ltr;
+  z-index: 2050!important; /* For bootstrap-modal */
   /*.dow {
 		border-top: 1px solid #ddd !important;
 	}*/


### PR DESCRIPTION
Without that the datepickers loaded in bootstrap-modal, went behind the modal container.
