### PR TITLE
Qualify events by namespace "bsDatepicker"

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -5,6 +5,7 @@ Datepicker triggers a number of events in certain circumstances.  All events hav
 
     $('.datepicker').datepicker()
         .on(picker_event, function(e){
+            # all the events are qualified by the namespace `bsDatepicker`. `picker_event` looks something like this: `show.bsDatepicker`
             # `e` here contains the extra attributes
         });
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -295,6 +295,7 @@
 
 			this.element.trigger({
 				type: event,
+				namespace: 'bsDatepicker',
 				date: local_date,
 				format: $.proxy(function(altformat){
 					var format = altformat || this.o.format;


### PR DESCRIPTION
Otherwise, it will be at the risk to pollute events from other controls

This [fiddle](http://jsfiddle.net/zekelu/dfbfe/) illustrates how event namespace works
