### PR TITLE
Don't open if input is disabled

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -304,6 +304,9 @@
 		},
 
 		show: function(e) {
+			if (this.element.is(':disabled'))
+		        	return;
+			
 			if (!this.isInline)
 				this.picker.appendTo('body');
 			this.picker.show();


### PR DESCRIPTION
The date picker was previously opening when the input it is associated with was disabled. This patch fixes this issue.
