### PR TITLE
Add zIndex to available options

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -420,9 +420,9 @@
 				windowHeight = $window.height(),
 				scrollTop = $window.scrollTop();
 
-			var zIndex = parseInt(this.element.parents().filter(function() {
+			var zIndex = this.o.zIndex || ( parseInt(this.element.parents().filter(function() {
 							return $(this).css('z-index') != 'auto';
-						}).first().css('z-index'))+10;
+						}).first().css('z-index'))+10 );
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);
@@ -1152,7 +1152,8 @@
 		startView: 0,
 		todayBtn: false,
 		todayHighlight: false,
-		weekStart: 0
+		weekStart: 0,
+		zIndex: null
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -33,6 +33,39 @@ test('Autoclose', function(){
     datesEqual(dp.viewDate, UTCDate(2012, 2, 4));
 });
 
+test('Zindex', function(){
+    // Test with option set
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    zIndex: 235
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+
+    input.focus();
+    ok(picker.is(':visible'), 'Picker is visible');
+    equal(picker.css('z-index'), 235); // Properly set zIndex
+
+    // zIndex from parent
+    $('#qunit-fixture').css({'z-index': '111'});
+
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({}),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+    ok(picker.is(':visible'), 'Picker is visible');
+    equal(picker.css('z-index'), 121); // Properly set zIndex
+});
+
 test('Startview: year view (integer)', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')


### PR DESCRIPTION
It's often useful to be able to set `z-index` on the datepicker when dealing with certain modals.  I've added an option to accept that as an argument to the jQuery function and test cases for this.
