### PR TITLE
Update composer.json to use component-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,19 @@
 {
-  "name": "eternicode/bootstrap-datepicker",
-  "require": {
-    "frameworks/jquery" : ">=1.7.1",
-    "twitter/bootstrap" : ">=2.0.4, <3.0"
-  }
+    "name": "eternicode/bootstrap-datepicker",
+    "type": "component",
+    "require": {
+        "robloach/component-installer": "*",
+        "components/bootstrap": ">=2.0.4,<3.0",
+        "components/jquery": ">=1.7.1"
+    },
+    "extra": {
+        "component": {
+            "scripts": [
+                "js/bootstrap-datepicker.js"
+            ],
+            "styles": [
+                "css/datepicker.css"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Most frontend components are now installable using the component-installer instead of just raw composer packages.

This would help immensely managing this package with a composer based project. 

See: https://github.com/RobLoach/component-installer
