### PR TITLE
fix problem for BS3 modal

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -305,7 +305,7 @@
 
 		show: function(e) {
 			if (!this.isInline)
-				this.picker.appendTo('body');
+				this.picker.appendTo(this.o.appendTo);
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.place();
@@ -1135,6 +1135,7 @@
 	};
 
 	var defaults = $.fn.datepicker.defaults = {
+		appendTo: 'body',
 		autoclose: false,
 		beforeShowDay: $.noop,
 		calendarWeeks: false,


### PR DESCRIPTION
If you add input in modal datepicker show under modal shadow layer.
Set 'appendTo' for fix this problem, eg.:

<pre>
$('.datepicker-input').datepicker({
    appendTo: "div.modal"
});
</pre>
