### PR TITLE
Option to specify tag datepicker is appended to

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -305,7 +305,7 @@
 
 		show: function(e) {
 			if (!this.isInline)
-				this.picker.appendTo('body');
+				this.picker.appendTo(this.o.appendTo || 'body');
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.place();


### PR DESCRIPTION
This is useful when a you want a datepicker in a modal on BS3 as the z-index of the modal means the datepicker is obscured.
