### PR TITLE
Fix 'this.date is undefined' on keyUp/keyDown and empty input (round2)

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -977,6 +977,8 @@
 				case 13: // enter
 					this.hide();
 					e.preventDefault();
+					e.stopPropagation && e.stopPropagation();
+					e.cancelBubble = true;
 					break;
 				case 9: // tab
 					this.hide();


### PR DESCRIPTION
To reproduce the fixed issue :
- get a empty input 
- $("input").datepicker()
- click on input (picker appears)
- press keyUp or keyDown
  You get on FF :

```
TypeError: this.date is undefined
Line : 964
```

Reproduced on IE11, Chrome and FF
