### PR TITLE
Fix 'this.date is undefined' on keyUp/keyDown and empty input (round3)

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -961,7 +961,7 @@
 						this._trigger('changeMonth', this.viewDate);
 					} else {
 						newDate = new Date(this.date || UTCToday());
-						newDate.setUTCDate(this.date.getUTCDate() + dir * 7);
+						newDate.setUTCDate(newDate.getUTCDate() + dir * 7);
 						newViewDate = new Date(this.viewDate);
 						newViewDate.setUTCDate(this.viewDate.getUTCDate() + dir * 7);
 					}


### PR DESCRIPTION
To reproduce the fixed issue :
- get a empty input 
- $("input").datepicker()
- click on input (picker appears)
- press keyUp or keyDown
  You get on FF :

```
TypeError: this.date is undefined
Line : 964
```

Reproduced on IE11, Chrome and FF
