### PR TITLE
Fix focus behavior on show/hide from add-on or input

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -225,6 +225,7 @@
 				this._events = [
 					[this.element, {
 						focus: $.proxy(this.show, this),
+						click: $.proxy(this.show, this),
 						keyup: $.proxy(function(){ this.update() }, this),
 						keydown: $.proxy(this.keydown, this)
 					}]
@@ -235,6 +236,7 @@
 					// For components that are not readonly, allow keyboard nav
 					[this.element.find('input'), {
 						focus: $.proxy(this.show, this),
+						click: $.proxy(this.show, this),
 						keyup: $.proxy(function(){ this.update() }, this),
 						keydown: $.proxy(this.keydown, this)
 					}],


### PR DESCRIPTION
Fix focus behavior on show/hide from add-on or input, based on work of #188
Fixed behavior :
- on click on add-on, the corresponding input get focus
- on hide of picker ESCAPE or selction+autoclose, input get focus
- on click on input, the picker is displayed but input keeps focus (including in modal container case)
