### PR TITLE
Fix estonian locale short day names and february short name

### DIFF
--- a/js/locales/bootstrap-datepicker.et.js
+++ b/js/locales/bootstrap-datepicker.et.js
@@ -11,7 +11,7 @@
 		months: ["Jaanuar", "Veebruar", "Märts", "Aprill", "Mai", "Juuni", "Juuli", "August", "September", "Oktoober", "November", "Detsember"],
 		monthsShort: ["Jaan", "Veebr", "Märts", "Apr", "Mai", "Juuni", "Juuli", "Aug", "Sept", "Okt", "Nov", "Dets"],
 		today: "Täna",
-		today: "Tühjenda",
+		clear: "Tühjenda",
 		weekStart: 1,
 		format: "dd.mm.yyyy"
 	};


### PR DESCRIPTION
I just realized that some of the translations were still a bit off. This PR fixes it. The translations are based on both CLDR data and jQuery UI Datepicker ET locale.
