### PR TITLE
z-index calculation should not stop at first element

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -425,6 +425,7 @@
 				var itemZIndex = $(this).css('z-index');
 				if ( itemZIndex != 'auto' && itemZIndex !== 0 ) parentsZindex.push( parseInt( itemZIndex ) );
 			});
+			var zIndex = Math.max.apply( Math, parentsZindex ) + 10;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);


### PR DESCRIPTION
i guess that when calculating proper z-index for the datepicker, we should find the max z-index value of parents() and not stop at first

related to #533 #170 #683 #678 #656 #665 #634 #621 #609 #464
