### PR TITLE
Fixed errors in build3.less, arguments were separated with ; instead of ...

### DIFF
--- a/build/build3.less
+++ b/build/build3.less
@@ -35,7 +35,7 @@
 // Mixins
 
 // Button variants
-.button-variant(@color; @background; @border) {
+.button-variant(@color, @background, @border) {
   color: @color;
   background-color: @background;
   border-color: @border;


### PR DESCRIPTION
...,

The less compiler gives errors when compiling build3.less. This was because the arguments in .button-variant where separated with semicolon instead of comma.
