### PR TITLE
Reordering @dropdown variables in build3.less

### DIFF
--- a/build/build_standalone3.less
+++ b/build/build_standalone3.less
@@ -16,11 +16,11 @@
 @table-bg:                      transparent; // overall background-color
 @dropdown-bg:                   #fff;
 @dropdow-border:                rgba(0,0,0,.15);
-@dropdown-link-active-bg:        @component-active-bg;
-@dropdown-link-color:            @gray-dark;
-@dropdown-link-hover-color:      #fff;
-@dropdown-link-hover-bg:         @dropdown-link-active-bg;
-@component-active-bg:            @brand-primary;
+@dropdown-link-color:           @gray-dark;
+@dropdown-link-hover-color:     #fff;
+@component-active-bg:           @brand-primary;
+@dropdown-link-active-bg:       @component-active-bg;
+@dropdown-link-hover-bg:        @dropdown-link-active-bg;
 
 // Drop shadows
 .box-shadow(@shadow) {


### PR DESCRIPTION
The @dropdown-link-active-bg and @dropdown-link-hover-bg need to be after @component-active-bg is declared else the compiler wont build the file. And because @dropdown-link-hover-bg depends on @dropdown-link-active-bg, @dropdown-link-hover-bg declaration need to come after.
