### PR TITLE
Added a mask layer to prevent mouse scrolling.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -99,6 +99,7 @@
 			this.component = false;
 
 		this.picker = $(DPGlobal.template);
+		this.mask = $(DPGlobal.maskTemplate);
 		this._buildEvents();
 		this._attachEvents();
 
@@ -405,8 +406,10 @@
 		},
 
 		show: function(e) {
-			if (!this.isInline)
+			if (!this.isInline) {
 				this.picker.appendTo('body');
+				this.mask.appendTo('body');
+			}
 			this.picker.show();
 			this.height = this.component ? this.component.outerHeight() : this.element.outerHeight();
 			this.place();
@@ -419,6 +422,7 @@
 			if (!this.picker.is(':visible')) return;
 			this.focusDate = null;
 			this.picker.hide().detach();
+			this.mask.detach();
 			this._detachSecondaryEvents();
 			this.viewMode = this.o.startView;
 			this.showMode();
@@ -439,6 +443,7 @@
 			this._detachEvents();
 			this._detachSecondaryEvents();
 			this.picker.remove();
+			this.mask.remove();
 			delete this.element.data().datepicker;
 			if (!this.isInput) {
 				delete this.element.data().date;
@@ -589,6 +594,11 @@
 				top: top,
 				left: left,
 				zIndex: zIndex
+			});
+			this.mask.css({
+				width: Math.max(document.documentElement.scrollWidth, $(window).width()),
+				height: Math.max(document.documentElement.scrollHeight, $(window).height()),
+				zIndex: zIndex - 1
 			});
 		},
 
@@ -1575,9 +1585,8 @@
 								'</table>'+
 							'</div>'+
 						'</div>';
-
+	DPGlobal.maskTemplate = '<div class="datepicker-mask" />';
 	$.fn.datepicker.DPGlobal = DPGlobal;
-
 
 	/* DATEPICKER NO CONFLICT
 	* =================== */

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -255,3 +255,10 @@
 		margin-right:-5px;
 	}
 }
+
+.datepicker-mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+

--- a/tests/suites/mouse_navigation/all.js
+++ b/tests/suites/mouse_navigation/all.js
@@ -31,3 +31,14 @@ test('Clicking outside datepicker hides datepicker', function(){
 
     $otherelement.remove();
 });
+
+test('Clicking on the datepicker mask hides the datepicker', function(){
+    var mask = this.dp.mask;
+
+    ok(this.picker.is(':visible'), 'Picker is visible');
+    this.input.trigger('click');
+    ok(this.picker.is(':visible'), 'Picker is still visible');
+
+    mask.trigger('mousedown');
+    ok(this.picker.is(':not(:visible)'), 'Picker is hidden');
+});


### PR DESCRIPTION
In certain cases when the datepicker is used on a section that has a scroll independent from the body, scrolling using the mouse wheel will result in the datepicker to remain still while the date input is moved, as shown in the following jsFiddle: http://jsfiddle.net/cesarFnord/yQf2r/

I added a mask layer that will prevent the mouse from scrolling to prevent this.
