### PR TITLE
Removed comment from compiled CSS.

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -13,10 +13,6 @@
   -moz-border-radius: 4px;
   border-radius: 4px;
   direction: ltr;
-  /*.dow {
-		border-top: 1px solid #ddd !important;
-	}*/
-
 }
 .datepicker-inline {
   width: 220px;

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -202,9 +202,9 @@
 			background: @grayLighter;
 		}
 	}
-	/*.dow {
-		border-top: 1px solid #ddd !important;
-	}*/
+	// .dow {
+	// 	border-top: 1px solid #ddd !important;
+	// }
 
 	// Basic styling for calendar-week cells
 	.cw {


### PR DESCRIPTION
Block comments are passed through into the compiled CSS, while line
comments are not. It seems appropriate to not pass commented styles
into the compiled CSS.
