### PR TITLE
Month lookups from text input are now case-insensitive.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1532,7 +1532,7 @@
 			function match_part(){
 				var m = this.slice(0, parts[i].length),
 					p = parts[i].slice(0, m.length);
-				return m === p;
+				return m.toLocaleLowerCase() === p.toLocaleLowerCase();
 			}
 			if (parts.length === fparts.length){
 				var cnt;


### PR DESCRIPTION
This should be a boon for ease of textual input; the prior sensitivity of the lookup could lead to missed month updates, especially if users casually expect the software to be smart enough with handling capitalisation for them (or just forget to do so).

The case of the month itself is unchanged, so the input text remains the same until it is replaced on a successful date update (in this case, when there is a correct date and text box focus is lost). This means that users will not be startled by changes _when typing_, but when the input stops consistency is correctly reasserted.
