### PR TITLE
Stop Propagation of Click Event

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -898,6 +898,7 @@
 
 		click: function(e){
 			e.preventDefault();
+			e.stopPropagation();
 			var target = $(e.target).closest('span, td, th'),
 				year, month, day;
 			if (target.length === 1){


### PR DESCRIPTION
Stop the propagation of the click event to prevent the parent handlers
