### PR TITLE
Fix colspan if calendarWeeks & clearBtn are true

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -116,7 +116,7 @@
 		this.viewMode = this.o.startView;
 
 		if (this.o.calendarWeeks)
-			this.picker.find('tfoot th.today')
+			this.picker.find('tfoot th.today, tfoot th.clear')
 						.attr('colspan', function(i, val){
 							return parseInt(val) + 1;
 						});


### PR DESCRIPTION
When calendarWeeks and clearBtn are true at the same time, the th arround the clearbutton has the wrong colspan.
