### PR TITLE
Prevent autocomplete on linked input

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -295,6 +295,7 @@
 		},
 		_buildEvents: function(){
 			if (this.isInput){ // single input
+				this.element.attr("autocomplete","off");
 				this._events = [
 					[this.element, {
 						focus: $.proxy(this.show, this),
@@ -307,6 +308,7 @@
 				];
 			}
 			else if (this.component && this.hasInput){ // component: input + button
+				this.element.find('input').attr("autocomplete","off");
 				this._events = [
 					// For components that are not readonly, allow keyboard nav
 					[this.element.find('input'), {


### PR DESCRIPTION
Prevent autocomplete on linked input since the keyboard navigation whith keyUp/keyDown displays another select with previous entries.
This PR add dynamically autocomplete="off" to attached input.
Updated PR of #675
