### PR TITLE
Fix focus behavior on show/hide from add-on or input

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -410,7 +410,7 @@
 			});
 		},
 
-		_focus: function(focus){
+		_focus: function(){
 			this.ignoreNextShowOnFocus = true;
 			var element = this.isInput? this.element : this.element.find('input');
 			setTimeout(function() { element.focus(); }, 0);


### PR DESCRIPTION
Fix focus behavior on show/hide from add-on or input, based on work of #188
Fixed behavior :
- on click on add-on, the corresponding input get focus
- on hide of picker ESCAPE or selction+autoclose, input get focus
- on click on input, the picker is displayed but input keeps focus (including in modal container case)

Updated PR of #677
