### PR TITLE
Fix IE7 z-index issue with modal

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -549,7 +549,7 @@
 
 			var zIndex = parseInt(this.element.parents().filter(function(){
 					var itemZIndex = $(this).css('z-index');
-					return itemZIndex != 'auto' && itemZIndex !== 0;
+					return itemZIndex !== 'auto' && itemZIndex !== 0;
 				}).first().css('z-index'))+10;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);


### PR DESCRIPTION
When a datepicker in within a BS modal, the dropdown is not visible in IE7 since IE7 return '0' and not 'auto' value for undefined attribute.
Credits : http://stackoverflow.com/questions/13074624/how-do-i-get-twitter-bootstrap-datepicker-to-work-in-ie7

Updated PR of #683
