### PR TITLE
Added option to disable touch keyboard input

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -414,6 +414,9 @@
 			this.place();
 			this._attachSecondaryEvents();
 			this._trigger('show');
+			if ((window.navigator.msMaxTouchPoints || 'ontouchstart' in document) && this.o.disableTouchKeyboard) {
+				$(this.element).blur();
+			}
 		},
 
 		hide: function(){
@@ -1408,7 +1411,8 @@
 		startView: 0,
 		todayBtn: false,
 		todayHighlight: false,
-		weekStart: 0
+		weekStart: 0,
+		disableTouchKeyboard: false
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',


### PR DESCRIPTION
Hopefully this should fix #787, I have managed to disable the touch input, at least on my phone, using the same checks as `jonthornton/jquery-timepicker`, as mentioned by @Gildeh
