### PR TITLE
Compare Dates by Day and ignore Hours Minutes and Seconds.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -45,9 +45,9 @@
 			contains: function(d){
 				// Array.indexOf is not cross-browser;
 				// $.inArray doesn't work with Dates
-				var val = d && d.valueOf();
+				var val = d && d.setHours(0,0,0,0).valueOf();
 				for (var i=0, l=this.length; i < l; i++)
-					if (this[i].valueOf() === val)
+					if (this[i].setHours(0,0,0,0).valueOf() === val)
 						return i;
 				return -1;
 			},


### PR DESCRIPTION
This will fix https://github.com/eternicode/bootstrap-datepicker/issues/864
