### PR TITLE
Adding parseDate option

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -151,6 +151,15 @@ A space-separated string consisting of one or two of "left" or "right", "top" or
 
 .. _startdate:
 
+
+parseDate
+---------
+
+Function(date, format, language).  Default: undefined
+
+If defined, this function will be called to parse dates prior to the default parsing logic.  If this function returns a Date value, it will be used as the parsed value.  If this function returns undefined, the date will be passed along to the default date parsing logic.
+
+
 startDate
 ---------
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -205,7 +205,7 @@
 					if (o.startDate instanceof Date)
 						o.startDate = this._local_to_utc(this._zero_time(o.startDate));
 					else
-						o.startDate = DPGlobal.parseDate(o.startDate, format, o.language);
+						o.startDate = this.parseDate(o.startDate, format, o.language);
 				} else {
 					o.startDate = -Infinity;
 				}
@@ -215,7 +215,7 @@
 					if (o.endDate instanceof Date)
 						o.endDate = this._local_to_utc(this._zero_time(o.endDate));
 					else
-						o.endDate = DPGlobal.parseDate(o.endDate, format, o.language);
+						o.endDate = this.parseDate(o.endDate, format, o.language);
 				} else {
 					o.endDate = Infinity;
 				}
@@ -527,6 +527,18 @@
 			this.updateNavArrows();
 		},
 
+		parseDate: function(date, format, language){
+			if('parseDate' in this.o && typeof(this.o.parseDate) === 'function') {
+				var result = this.o.parseDate(date, format, language);
+			}
+
+			if(result === undefined) {
+				result = DPGlobal.parseDate(date, format, language);
+			}
+
+			return result;
+		},
+
 		place: function(){
 						if(this.isInline) return;
 			var calendarWidth = this.picker.outerWidth(),
@@ -617,7 +629,7 @@
 			}
 
 			dates = $.map(dates, $.proxy(function(date){
-				return DPGlobal.parseDate(date, this.o.format, this.o.language);
+				return this.parseDate(date, this.o.format, this.o.language);
 			}, this));
 			dates = $.grep(dates, $.proxy(function(date){
 				return (

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -233,3 +233,5 @@ test('Trailing separators', patch_date(function(Date){
         .datepicker('setValue');
     equal(this.input.val(), '29.02.2012.');
 }));
+
+

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -646,3 +646,58 @@ test('Multidate Separator', function(){
     target.click();
     equal(input.val(), '2012-03-05 2012-03-04 2012-03-12');
 });
+
+test('Custom parseDate function returns undefined', function(){
+    var parseDate = function() {};
+
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('2012-03-05')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    parseDate: parseDate
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    var actual = input.datepicker('getUTCDate');
+    var expected = UTCDate(2012, 2, 5); 
+
+    console.log(actual);
+    console.log(expected);
+    datesEqual(actual, expected);
+});
+
+test('Custom parseDate function parses date', function(){
+    var parseDate = function(date, format, language) {
+        console.log(typeof(date));
+        if(typeof(date) === 'string') {
+            var year = date.substring(0, 4);
+            var month = date.substring(4, 6) - 1;
+            var day = date.substring(6);
+
+            console.log(year);
+            console.log(month);
+            console.log(day);
+
+            return UTCDate(year, month, day);
+        }
+    };
+
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .val('20120305')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    parseDate: parseDate
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    var actual = input.datepicker('getUTCDate');
+    var expected = UTCDate(2012, 2, 5);
+
+    datesEqual(actual, expected);
+});


### PR DESCRIPTION
I added a parseDate option that takes a function. If this option is set, the function will be called prior to calling DPGlobal.parseDate. If it returns a value, that value will be used as the parsed value. If it returns undefined, DPGlobal.parseDate will be called to parse the value. This option will allow completely custom date parsing logic.

My use case for this is that our app needs to take strings like '0227' and infer the date 2/27/2014 based on other context we have available in the app. This doesn't fit into the realm of custom formatting nicely so I need an option to completely override the date parsing logic when needed.

All existing test pass. I also added two new tests to cover this area. First, pass parseDate function that returns undefined. Second, pass parseDate function that actually parses the date. Both new tests pass.
