### PR TITLE
Update datepicker3.less: input-daterange to full width

### DIFF
--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -225,6 +225,7 @@
 	}
 }
 .input-daterange {
+	width: 100%;
 	input {
 		text-align:center;
 	}


### PR DESCRIPTION
To act, by default, like a normal input tag with 100% width like here :)
![normal input](https://cloud.githubusercontent.com/assets/985838/2642791/e4cdc714-bf0e-11e3-91a6-1f45c7b04ad7.png)
