### PR TITLE
Bug fix with range picker when next date is before previous date.

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1284,6 +1284,7 @@
 			var dp = $(e.target).data('datepicker'),
 				new_date = dp.getUTCDate(),
 				i = $.inArray(e.target, this.inputs),
+				j = i - 1,
 				l = this.inputs.length;
 			if (i === -1)
 				return;
@@ -1293,10 +1294,10 @@
 					p.setUTCDate(new_date);
 			});
 
-			if (new_date < this.dates[i]){
+			if (new_date < this.dates[j]){
 				// Date being moved earlier/left
-				while (i >= 0 && new_date < this.dates[i]){
-					this.pickers[i--].setUTCDate(new_date);
+				while (j >= 0 && new_date < this.dates[j]){
+					this.pickers[j--].setUTCDate(new_date);
 				}
 			}
 			else if (new_date > this.dates[i]){


### PR DESCRIPTION
There is a bug in range picker if you pick the next date before the previous date at first time.

Steps to reproduce:

http://eternicode.github.io/bootstrap-datepicker

Select range picker.
In first input select some date.
In second input select the date before first date.

The first date will not immediately change to be the same as second.
You have to change first one again to something in future and then it works fine.
#914 related.
