### PR TITLE
Remove font-family declaration for datepicker

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -502,7 +502,6 @@
   *border-right-width: 2px;
   *border-bottom-width: 2px;
   color: #333333;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 13px;
   line-height: 20px;
 }


### PR DESCRIPTION
Datepicker shouldn't specify a font-family - it should simply inherit the parent body's font. 

This way, it'll confirm to the implementation page's standards.
