### PR TITLE
Fix translation of French months

### DIFF
--- a/js/locales/bootstrap-datepicker.fr.js
+++ b/js/locales/bootstrap-datepicker.fr.js
@@ -5,10 +5,10 @@
 ;(function($){
 	$.fn.datepicker.dates['fr'] = {
 		days: ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"],
-		daysShort: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"],
+		daysShort: ["Dim.", "Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam.", "Dim."],
 		daysMin: ["D", "L", "Ma", "Me", "J", "V", "S", "D"],
 		months: ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"],
-		monthsShort: ["Jan", "Fév", "Mar", "Avr", "Mai", "Jui", "Jul", "Aou", "Sep", "Oct", "Nov", "Déc"],
+		monthsShort: ["Janv.", "Févr.", "Mars", "Avril", "Mai", "Juin", "Juil.", "Août", "Sept.", "Oct.", "Nov.", "Déc."],
 		today: "Aujourd'hui",
 		clear: "Effacer",
 		weekStart: 1,


### PR DESCRIPTION
Official translation of French months (followed by glibc, GNOME and
so on). See http://fr.wikipedia.org/wiki/Mois.

For references:
- date widget Chrome in HTML5
- https://github.com/jquery/jquery-ui/blob/master/ui/i18n/datepicker-fr.js
- GNU coreutils, glib, GNOME, etc
