### PR TITLE
Additional bug fix to range picker when next date is before previous date

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1285,6 +1285,7 @@
 				new_date = dp.getUTCDate(),
 				i = $.inArray(e.target, this.inputs),
 				j = i - 1,
+				k = i + 1,
 				l = this.inputs.length;
 			if (i === -1)
 				return;
@@ -1300,10 +1301,10 @@
 					this.pickers[j--].setUTCDate(new_date);
 				}
 			}
-			else if (new_date > this.dates[i]){
+			else if (new_date > this.dates[k]){
 				// Date being moved later/right
-				while (i < l && new_date > this.dates[i]){
-					this.pickers[i++].setUTCDate(new_date);
+				while (k < l && new_date > this.dates[k]){
+					this.pickers[k++].setUTCDate(new_date);
 				}
 			}
 			this.updateDates();


### PR DESCRIPTION
This PR contains some additional to outstanding PR #937

Steps to reproduce:

http://eternicode.github.io/bootstrap-datepicker
1. Select range picker.
2. In second input select some date.
3. In first input select the date after the second date.

Expected: The second date will not immediately change to be the same as first.

Actual: You have to change first one again to something in future and then it works fine.
