### PR TITLE
Add new Boolean option: oldNewDisabled .

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -127,6 +127,12 @@
   color: #999999;
   cursor: default;
 }
+.datepicker table tr td.disable-old,
+.datepicker table tr td.disable-old:hover,
+.datepicker table tr td.disable-new,
+.datepicker table tr td.disable-new:hover {
+  color: #eeeeee;
+}
 .datepicker table tr td.today,
 .datepicker table tr td.today:hover,
 .datepicker table tr td.today.disabled,

--- a/css/datepicker3.css
+++ b/css/datepicker3.css
@@ -123,6 +123,12 @@
   color: #999999;
   cursor: default;
 }
+.datepicker table tr td.disable-old,
+.datepicker table tr td.disable-old:hover,
+.datepicker table tr td.disable-new,
+.datepicker table tr td.disable-new:hover {
+  color: #eeeeee;
+}
 .datepicker table tr td.today,
 .datepicker table tr td.today:hover,
 .datepicker table tr td.today.disabled,

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -703,10 +703,10 @@
 				month = this.viewDate.getUTCMonth(),
 				today = new Date();
 			if (date.getUTCFullYear() < year || (date.getUTCFullYear() === year && date.getUTCMonth() < month)){
-				cls.push('old');
+				cls.push(( this.o.oldNewDisabled ? 'disabled disable-old' : 'old'));
 			}
 			else if (date.getUTCFullYear() > year || (date.getUTCFullYear() === year && date.getUTCMonth() > month)){
-				cls.push('new');
+				cls.push(( this.o.oldNewDisabled ? 'disabled disable-new' : 'new'));
 			}
 			if (this.focusDate && date.valueOf() === this.focusDate.valueOf())
 				cls.push('focused');
@@ -1408,7 +1408,8 @@
 		startView: 0,
 		todayBtn: false,
 		todayHighlight: false,
-		weekStart: 0
+		weekStart: 0,
+		oldNewDisabled: false
 	};
 	var locale_opts = $.fn.datepicker.locale_opts = [
 		'format',

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -176,6 +176,12 @@
 				color: @grayLight;
 				cursor: default;
 			}
+			&.disable-old,
+			&.disable-old:hover,
+			&.disable-new,
+			&.disable-new:hover {
+				color: @grayLighter;
+			}
 			&.active,
 			&.active:hover,
 			&.active.disabled,

--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -174,6 +174,12 @@
 				color: @btn-link-disabled-color;
 				cursor: default;
 			}
+			&.disable-old,
+			&.disable-old:hover,
+			&.disable-new,
+			&.disable-new:hover {
+				color: @gray-lighter;
+			}
 			&.active,
 			&.active:hover,
 			&.active.disabled,


### PR DESCRIPTION
- Default is false. Disables click events on old & new dates in current month. Useful when complex rules assigned via private API data('datepicker')._process_options() are only valid in current month.
