### PR TITLE
fix for pressing enter after, manually entering the date

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1018,7 +1018,12 @@
 				this.dates.clear();
 			}
 			else if (ix !== -1){
-				this.dates.remove(ix);
+				if(!this.isInput){
+					this.dates.remove(ix); //fix for pressing enter after manually typing date.
+				}
+				else if(this.o.autoclose){
+					this.hide();
+				}
 			}
 			else {
 				this.dates.push(date);


### PR DESCRIPTION
When pressing enter aftet manually typing a date in datepicker the selection disappears. 
Fixed that behaviour by checking if the focussed date is same as input date then do not remove it.
