### PR TITLE
Check tooltip is undefined, not just empty which allows it to be reset

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -527,11 +527,11 @@
 					clsName.push('disabled');
 				if (before.classes)
 					clsName = clsName.concat(before.classes.split(/\s+/));
-				if (before.tooltip)
+				if (typeof(before.tooltip) !== 'undefined')
 					tooltip = before.tooltip;
 
 				clsName = $.unique(clsName);
-				html.push('<td class="'+clsName.join(' ')+'"' + (tooltip ? ' title="'+tooltip+'"' : '') + '>'+prevMonth.getUTCDate() + '</td>');
+				html.push('<td class="'+clsName.join(' ')+'"' + (typeof(tooltip) !== 'undefined' ? ' title="'+tooltip+'"' : '') + '>'+prevMonth.getUTCDate() + '</td>');
 				if (prevMonth.getUTCDay() == this.weekEnd) {
 					html.push('</tr>');
 				}


### PR DESCRIPTION
Hey, haven't had a chance to add a unit test yet, however I've found something that looks a bit like a bug.

If you're changing the onBeforeShowDay after the object is instantiated so you can, for example, change which tooltips are available in response to a visitor's choices, it's necessary to manually reset the tooltip, e.g.:

```
                    widget.o.beforeShowDay = function(datepickerDate){
                        if(someConditionForThisDateIsTrue){
                            return {
                                'enabled': true,
                                'tooltip': ''
                            };
                        }else{
                            return {
                                'enabled': false,
                                'tooltip': 'Sorry, not available on this date'
                            };
                        }
                    };
```

This doesn't work because the plugin just checks the date evaluates to false, which stops it being reset back to ''.

This pull request fixes that by checking for undefined instead of true/false.
