### PR TITLE
Update options.rst

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -83,9 +83,7 @@ String.  Default: "mm/dd/yyyy"
 The date format, combination of d, dd, D, DD, m, mm, M, MM, yy, yyyy.
 
 * d, dd: Numeric date, no leading zero and leading zero, respectively.  Eg, 5, 05.
-* D, DD: Abbreviated and full weekday names, respectively.  Eg, Mon, Monday.
 * m, mm: Numeric month, no leading zero and leading zero, respectively.  Eg, 7, 07.
-* M, MM: Abbreviated and full month names, respectively.  Eg, Jan, January
 * yy, yyyy: 2- and 4-digit years, respectively.  Eg, 12, 2012.
 
 


### PR DESCRIPTION
The D,DD and M,MM format is not available as per the docs here http://www.eyecon.ro/bootstrap-datepicker/. Also using D,DD,M,MM as date format doesn't show the datepicker.
