### PR TITLE
Correccion

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -547,7 +547,7 @@
 				windowHeight = $window.height(),
 				scrollTop = $window.scrollTop();
 
-			var zIndex = parseInt(this.element.children().filter(function(){
+			var zIndex = parseInt($("body").children().filter(function(){
 					return $(this).css('z-index') !== 'auto';
 				}).first().css('z-index'))+10;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();


### PR DESCRIPTION
se cambia la linea 550 var zIndex = parseInt(this.element.parents()... por var zIndex = parseInt($("body").children()...

Cuando se encuentran dos divs a la misma altura, en uno de estos divs se encuentra el datepicker y en otro div se encuentra un elemento con un z-index mayor al cualquier otro elemento, este se sobrepone por el datepicker, ya que no pertenece a los parents del datepicker. Es mejor buscar del body hacia abajo, con la funcion children.
