### PR TITLE
fix problem with date object constructor in firefox

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -759,7 +759,7 @@
 				day = DPGlobal.getDaysInMonth(prevMonth.getUTCFullYear(), prevMonth.getUTCMonth());
 			prevMonth.setUTCDate(day);
 			prevMonth.setUTCDate(day - (prevMonth.getUTCDay() - this.o.weekStart + 7)%7);
-			var nextMonth = new Date(prevMonth);
+			var nextMonth = new Date(prevMonth.valueOf());
 			nextMonth.setUTCDate(nextMonth.getUTCDate() + 42);
 			nextMonth = nextMonth.valueOf();
 			var html = [];


### PR DESCRIPTION
Firefox has a problem when creating new date objects from existing date objects - at least if date is 0100-01-01. nextMonth will become 2000-01-01 so Firefox renders slightly more than 6 weeks (actually freezes). valueOf() solves the issue:

var nextMonth = new Date(prevMonth.valueOf());

---

It's not easily possible to write a test-case for this, if this is not actually run in firefox. However, this issue is reproducable in firefox, add an input field with value set to `01.01.100`. Opening this page in firefox crashes it. After applying this fix, everything works fine.
