### PR TITLE
Do not show datepicker for readonly inputs

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -408,6 +408,8 @@
 		},
 
 		show: function(){
+			if (this.element.attr('readonly'))
+				return;
 			if (!this.isInline)
 				this.picker.appendTo('body');
 			this.picker.show();


### PR DESCRIPTION
Currently, calling `$(el).datepicker()` on a readonly input (`<input type="text" readonly/>`) enables users to modify its content. This patch disables the datepicker popup from showing when an `<input/>` is readonly.
