### PR TITLE
Fix getUTCDate when datepicker has no selected date

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -478,7 +478,12 @@
 		},
 
 		getUTCDate: function(){
-			return new Date(this.dates.get(-1));
+			var selected_date = this.dates.get(-1);
+			if (typeof selected_date !== 'undefined') {
+				return new Date(selected_date);
+			} else {
+				return null;
+			}
 		},
 
 		setDates: function(){


### PR DESCRIPTION
This PR fixes #923  (or should fix) 

Only question left, should we return null or current date? My personal preference would be just null as current date is not correct as no date is selected
