### PR TITLE
Fixed 'tip' triangle for top-positioned calendars

### DIFF
--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -43,11 +43,13 @@
 			bottom: -7px;
 			border-bottom: 0;
 			border-top:    7px solid @dropdown-border;
+			top: initial;
 		}
 		&.datepicker-orient-top:after {
 			bottom: -6px;
 			border-bottom: 0;
 			border-top:    6px solid @dropdown-bg;
+			top: initial;
 		}
 	}
 	> div {


### PR DESCRIPTION
Fix for the orientation-top class (used when calendars renders above the input field).

The problem was that the 'tip' triangle was left dangling above the calendar, and it should be moved to the bottom.

The fix is really simple: when we apply a position-bottom value, then we MUST reset the top value. I do that with `top: initial`.

Browser: Chrome Version 47.0.2526.8 dev (64-bit)
