### PR TITLE
UTC to local date conversion incorrect on daylight saving boundary

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -529,7 +529,7 @@
 		},
 
 		_utc_to_local: function(utc){
-			return utc && new Date(utc.getTime() + (utc.getTimezoneOffset()*60000));
+			return utc && new Date(utc.getUTCFullYear(), utc.getUTCMonth(), utc.getUTCDate(), utc.getUTCHours(), utc.getUTCMinutes(), utc.getUTCSeconds(), utc.getUTCMilliseconds());
 		},
 		_local_to_utc: function(local){
 			return local && new Date(local.getTime() - (local.getTimezoneOffset()*60000));


### PR DESCRIPTION
Candidate fix for 
https://github.com/eternicode/bootstrap-datepicker/issues/1274

This PR contains the UTC -> local date conversion fix applied to dalelotts/angular-bootstrap-datetimepicker to remedy the same issue in their repo.
https://github.com/dalelotts/angular-bootstrap-datetimepicker/commit/74488250e4e08070b4bb67fdd541009f3ad113fc

Can anyone who knows this codebase comment on whether this would also be an issue in the reverse direction (_local_to_utc)? That method also uses getTimezoneOffset().
