### PR TITLE
Removing sourceMappingURL from not-minified verson

### DIFF
--- a/dist/css/bootstrap-datepicker.standalone.css
+++ b/dist/css/bootstrap-datepicker.standalone.css
@@ -507,4 +507,3 @@
 .datepicker.datepicker-inline td {
   padding: 4px 5px;
 }
-/*# sourceMappingURL=bootstrap-datepicker.standalone.css.map */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #1795 
| License         | MIT

The not-minified version of the CSS doesn't need the source mapping. The mapping is not used when the full CSS version is being used.

Here where I work, we use this plugin with the not minified version, and Rails minifies and compile the CSS for us, so the source mapping on the full CSS doesn't make sense.