### PR TITLE
Improve defaultViewDate documentation

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -175,6 +175,7 @@ Date to view when initially opening the calendar. The internal value of the date
  * ``month``: 0
  * ``day``: 1
 
+Note that the month parameter starts at 0 for January.
 
 disableTouchKeyboard
 --------------------


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #2051

Fix documentation to be more clear about month parameter being zero based on the defaultViewDate option