### PR TITLE
Allow Date/String for defaultViewDate option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 Changelog
 =========
 
-1.7.0
------
-
-Features
- * Added support for dates/strings to defaultViewDate option
-
 1.5.1
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.7.0
+-----
+
+Features
+ * Added support for dates/strings to defaultViewDate option
+
 1.5.1
 -----
 

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -167,15 +167,18 @@ Days of the week that should be highlighted. Values are 0 (Sunday) to 6 (Saturda
 defaultViewDate
 ---------------
 
-Object with keys ``year``, ``month``, and ``day``. Default: today
+Date, String or Object with keys ``year``, ``month``, and ``day``. Default: today
 
-Date to view when initially opening the calendar. The internal value of the date remains today as default, but when the datepicker is first opened the calendar will open to ``defaultViewDate`` rather than today. If this option is not used, "today" remains the default view date. If the given object is missing any of the required keys, their defaults are:
+Date to view when initially opening the calendar. The internal value of the date remains today as default, but when the datepicker is first opened the calendar will open to ``defaultViewDate`` rather than today. If this option is not used, "today" remains the default view date.
 
- * ``year``: the current year
- * ``month``: 0
- * ``day``: 1
+This option can be:
+ * A date, which should be in local timezone.
+ * A string which must be parsable with ``format``.
+ * An object with keys ``year``, ``month`` and ``day`` (can't be set from a data attribute). If the given object is missing any of the required keys, their defaults are:
 
-Note that the month parameter starts at 0 for January.
+   * ``year``: the current year
+   * ``month``: 0 (Note that it starts with 0 for January)
+   * ``day``: 1
 
 disableTouchKeyboard
 --------------------

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -306,7 +306,9 @@
 				});
 				o.orientation.y = _plc[0] || 'auto';
 			}
-			if (o.defaultViewDate) {
+			if (o.defaultViewDate instanceof Date || typeof o.defaultViewDate === "string") {
+				o.defaultViewDate = DPGlobal.parseDate(o.defaultViewDate, format, o.language, o.assumeNearbyYear);
+			} else if (o.defaultViewDate) {
 				var year = o.defaultViewDate.year || new Date().getFullYear();
 				var month = o.defaultViewDate.month || 0;
 				var day = o.defaultViewDate.day || 1;

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1275,12 +1275,44 @@ test('Container', function(){
     equal(target.parent()[0], testContainer[0], 'Container is not the testContainer that was specificed');
 });
 
-test('Default View Date', function(){
+test('Default View Date (Object)', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')
                 .datepicker({
                     format: 'yyyy-mm-dd',
                     defaultViewDate: { year: 1977, month: 04, day: 25 }
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+
+    equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'May 1977');
+});
+
+test('Default View Date (Date)', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    defaultViewDate: new Date(1977, 4, 25)
+                }),
+        dp = input.data('datepicker'),
+        picker = dp.picker,
+        target;
+
+    input.focus();
+
+    equal(picker.find('.datepicker-days thead .datepicker-switch').text(), 'May 1977');
+});
+
+test('Default View Date (String)', function(){
+    var input = $('<input />')
+                .appendTo('#qunit-fixture')
+                .datepicker({
+                    format: 'yyyy-mm-dd',
+                    defaultViewDate: "1977-05-24"
                 }),
         dp = input.data('datepicker'),
         picker = dp.picker,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | fixes #1611 (at least for the OP's use case where all three values are set) and #1550
| License         | MIT
