### PR TITLE
moved assumeNearbyYear to correct location

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -16,6 +16,16 @@ Boolean.  Default: false
 Whether or not to close the datepicker immediately when a date is selected.
 
 
+assumeNearbyYear
+----------------
+
+Boolean or Integer.  Default: false
+
+If true, manually-entered dates with two-digit years, such as "5/1/15", will be parsed as "2015", not "15". If the year is less than 10 years in advance, the picker will use the current century, otherwise, it will use the previous one. For example "5/1/15" would parse to May 1st, 2015, but "5/1/97" would be May 1st, 1997.
+
+To configure the number of years in advance that the picker will still use the current century, use an Integer instead of the Boolean true. E.g. "assumeNearbyYear: 20"
+
+
 beforeShowDay
 -------------
 
@@ -224,16 +234,6 @@ forceParse
 Boolean.  Default: true
 
 Whether or not to force parsing of the input value when the picker is closed.  That is, when an invalid date is left in the input field by the user, the picker will forcibly parse that value, and set the input's value to the new, valid date, conforming to the given `format`.
-
-
-assumeNearbyYear
-----------------
-
-Boolean or Integer.  Default: false
-
-If true, manually-entered dates with two-digit years, such as "5/1/15", will be parsed as "2015", not "15". If the year is less than 10 years in advance, the picker will use the current century, otherwise, it will use the previous one. For example "5/1/15" would parse to May 1st, 2015, but "5/1/97" would be May 1st, 1997.
-
-To configure the number of years in advance that the picker will still use the current century, use an Integer instead of the Boolean true. E.g. "assumeNearbyYear: 20"
 
 
 format
@@ -526,6 +526,7 @@ This is a quick overview of all the options and their default values
 Option                       Default value
 =====================        =============
 autoclose                    false
+assumeNearbyYear             false
 beforeShowDay
 beforeShowMonth
 beforeShowYear
@@ -542,7 +543,6 @@ disableTouchKeyboard         false
 enableOnReadonly             true
 endDate                      Infinity
 forceParse                   true
-assumeNearbyYear             false
 format                       'mm/dd/yyyy'
 immediateUpdates             false
 inputs


### PR DESCRIPTION
The assumeNearbyYear option was between options starting with an 'f'. Moved it to the correct alphabetical order.

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
