### PR TITLE
move `jquery` to `peerDependencies` from `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "type": "git",
     "url": "https://github.com/uxsolutions/bootstrap-datepicker.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=1.7.1 <4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | should not
| License         | MIT

After this patch `jquery` is removed from the `dependencies` section of `package.json` and granted `peerDependencies` status instead of it.

Rationale:
- Both of these packages (`bootstrap-datepicker` and `jquery`) are quite likely to be defined as dependencies of their common parent application (which is, most likely, a web site; could also be an application built on [Electron](http://electron.atom.io/), [NW.js](http://nwjs.io/), [JXcore for Cordova](https://github.com/jxcore/jxcore-cordova/), etc.) and thus to become peers in that sense. Currently, if some version mismatch happens on that level (under that common parent), `npm` would install another version of `jquery` under `bootstrap-datepicker` (and that would be the version required by `bootstrap-datepicker` in its `dependencies`). However, `bootstrap-datepicker` does not rely on Node.js `require()` unless a CommonJS environment is encountered by UMD, in any other environment that npm's behaviour does not really help anything, and thus `npm` should rather **warn** on version mismatch (like it does with `peerDependencies`) and refrain from trying to fix things.
- Likewise, if a user has some reason to refrain from `npm install jquery` (for example, that user might prefer to use a `<script src="…">` tag referencing [jQuery CDN](https://code.jquery.com/) instead of a local npm-installed jQuery), then `npm` should not decide to install jQuery as a dependency (which won't be used anyway); a warning about a missing peerDependency would be enough.