### PR TITLE
Romanian uses dd/mm/yyyy format for dates

### DIFF
--- a/js/locales/bootstrap-datepicker.ro.js
+++ b/js/locales/bootstrap-datepicker.ro.js
@@ -11,6 +11,7 @@
 		monthsShort: ["Ian", "Feb", "Mar", "Apr", "Mai", "Iun", "Iul", "Aug", "Sep", "Oct", "Nov", "Dec"],
 		today: "Astăzi",
 		clear: "Șterge",
-		weekStart: 1
+		weekStart: 1,
+		format: "dd/mm/yyyy"
 	};
 }(jQuery));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Corrected the date format for Romanian locale.
