### PR TITLE
Update markup.rst

### DIFF
--- a/docs/markup.rst
+++ b/docs/markup.rst
@@ -51,13 +51,11 @@ Using the ``input-daterange`` construct with multiple child inputs will instanti
 .. figure:: _static/screenshots/markup_daterange.png
     :align: center
 
-Note that that ``input-daterange`` itself does not implement the ``datepicker`` methods. Methods should be directly called to the inputs. For example:
+Note that that ``input-daterange`` itself also implements the ``datepicker`` methods. For example:
 
 ::
 
-    $('.input-daterange input').each(function() {
-        $(this).datepicker('clearDates');
-    });
+    $('.input-daterange').datepicker();
 
 inline or embedded
 ------------------


### PR DESCRIPTION
I found that in current version, 'input-daterange' actually implements the datepicker method, and the code example below runs well.
`$('.input-daterange').datepicker()` 
On the other hand, the original code example proposed, i.e. 
`$('.input-daterange input').each(function() {
    $(this).datepicker('clearDates');
});` , 
breaks the connection between "start" and "end" inputs. For example, it does not add proper listener on "changeDate" event.

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
