### PR TITLE
blur inputField on hide so focus event can fire again

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -502,6 +502,7 @@
 
 			if (this.o.forceParse && this.inputField.val())
 				this.setValue();
+			this.inputField.blur();
 			this._trigger('hide');
 			return this;
 		},


### PR DESCRIPTION
The datepicker is hidden if you scroll while it is open, but the inputField remains focused.  The focus prevents it from showing again if you click on the input because the onFocus event does not fire until you click off of the input and then click it again.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT
