### PR TITLE
Revert "move `jquery` to `peerDependencies` from `dependencies`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "type": "git",
     "url": "https://github.com/uxsolutions/bootstrap-datepicker.git"
   },
-  "peerDependencies": {
+  "dependencies": {
     "jquery": ">=1.7.1 <4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts uxsolutions/bootstrap-datepicker#2163

Fixes #2206 

If necessary we can introduce this change in 2.0