### PR TITLE
Allows for use within webpack

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -18,7 +18,9 @@
  * ========================================================= */
 
 (function(factory){
-    if (typeof define === "function" && define.amd) {
+    if (typeof jQuery === "function" && jQuery.fn) {
+        factory(jQuery);
+    } else if (typeof define === "function" && define.amd) {
         define(["jquery"], factory);
     } else if (typeof exports === 'object') {
         factory(require('jquery'));


### PR DESCRIPTION
The initial factory function is attempting to import a new instance of jquery before checking for a  globally defined one. If you have a globally defined jquery and you are building within a webpack environment it will import a new instance of jquery and miss the one you are using. So now we are checking for globals first instead of trying to import first.

| Q               | A
| --------------- | ---
| Bug fix?        yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
