### PR TITLE
Added monthsTitle to Latvian locale

### DIFF
--- a/js/locales/bootstrap-datepicker.lv.js
+++ b/js/locales/bootstrap-datepicker.lv.js
@@ -10,6 +10,7 @@
         daysMin: ["Sv", "Pr", "Ot", "Tr", "Ce", "Pk", "Se"],
         months: ["Janvāris", "Februāris", "Marts", "Aprīlis", "Maijs", "Jūnijs", "Jūlijs", "Augusts", "Septembris", "Oktobris", "Novembris", "Decembris"],
         monthsShort: ["Jan", "Feb", "Mar", "Apr", "Mai", "Jūn", "Jūl", "Aug", "Sep", "Okt", "Nov", "Dec"],
+        monthsTitle: "Mēneši",
         today: "Šodien",
         clear: "Nodzēst",
         weekStart: 1


### PR DESCRIPTION
Hi,

I've added missing "monthsTitle" property in Latvian language.

Thanks.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | N/A
| License         | MIT
