### PR TITLE
Update bootstrap-datepicker.js

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -454,7 +454,7 @@
 			this._unapplyEvents(this._secondaryEvents);
 		},
 		_trigger: function(event, altdate){
-			var date = altdate || this.dates.get(-1),
+			var date = altdate || this.dates.get(this.dates.contains(this.viewDate)),
 				local_date = this._utc_to_local(date);
 
 			this.element.trigger({


### PR DESCRIPTION
Trigger(s) always return the last date in dates array when we use setDate, setDates, etc., to set dates. There is no way to get the clicked date (among already selected dates). This change will return the clicked date if updateViewDate is true, and the last date in dates array if updateViewDate is false.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
