### PR TITLE
Options priority change

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -1650,8 +1650,8 @@
 					// Preliminary otions
 					xopts = $.extend({}, defaults, elopts, options),
 					locopts = opts_from_locale(xopts.language),
-					// Options priority: js args, data-attrs, locales, defaults
-					opts = $.extend({}, defaults, locopts, elopts, options);
+					// Options priority: data-attrs, js args, locales, defaults
+					opts = $.extend({}, defaults, locopts, options, elopts);
 				if ($this.hasClass('input-daterange') || opts.inputs){
 					$.extend(opts, {
 						inputs: opts.inputs || $this.find('input').toArray()


### PR DESCRIPTION
Changed data-attrs options priority since js args are commonly executed for all inputs and data-attrs should override them.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #2335 
| License         | MIT
