### PR TITLE
Change Swedish days and months to lowercase

### DIFF
--- a/js/locales/bootstrap-datepicker.sv.js
+++ b/js/locales/bootstrap-datepicker.sv.js
@@ -4,11 +4,11 @@
  */
 ;(function($){
 	$.fn.datepicker.dates['sv'] = {
-		days: ["Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag"],
-		daysShort: ["Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör"],
-		daysMin: ["Sö", "Må", "Ti", "On", "To", "Fr", "Lö"],
-		months: ["Januari", "Februari", "Mars", "April", "Maj", "Juni", "Juli", "Augusti", "September", "Oktober", "November", "December"],
-		monthsShort: ["Jan", "Feb", "Mar", "Apr", "Maj", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"],
+		days: ["söndag", "måndag", "tisdag", "onsdag", "torsdag", "fredag", "lördag"],
+		daysShort: ["sön", "mån", "tis", "ons", "tor", "fre", "lör"],
+		daysMin: ["sö", "må", "ti", "on", "to", "fr", "lö"],
+		months: ["januari", "februari", "mars", "april", "maj", "juni", "juli", "augusti", "september", "oktober", "november", "december"],
+		monthsShort: ["jan", "feb", "mar", "apr", "maj", "jun", "jul", "aug", "sep", "okt", "nov", "dec"],
 		today: "Idag",
 		format: "yyyy-mm-dd",
 		weekStart: 1,


### PR DESCRIPTION
Days and months are lowercase in Swedish

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
