### PR TITLE
Removed text-shadow from input-group-addon

### DIFF
--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -250,7 +250,6 @@
 		min-width: 16px;
 		padding: 4px 5px;
 		line-height: @line-height-base;
-		text-shadow: 0 1px 0 #fff;
 		border-width: 1px 0;
 		margin-left: -5px;
 		margin-right: -5px;


### PR DESCRIPTION
Removed text-shadow from input-group-addon to match bootstrap3 input-group-addon

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #2340 
| License         | MIT
