### PR TITLE
Added not first/last-child on input-group-addon

### DIFF
--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -246,13 +246,15 @@
 		border-radius: 0 3px 3px 0;
 	}
 	.input-group-addon {
-		width: auto;
-		min-width: 16px;
-		padding: 4px 5px;
-		line-height: @line-height-base;
-		text-shadow: 0 1px 0 #fff;
-		border-width: 1px 0;
-		margin-left: -5px;
-		margin-right: -5px;
+    :not(:first-child):not(:last-child) {
+      width: auto;
+      min-width: 16px;
+      padding: 4px 5px;
+      line-height: @line-height-base;
+      text-shadow: 0 1px 0 #fff;
+      border-width: 1px 0;
+      margin-left: -5px;
+      margin-right: -5px;
+    }
 	}
 }


### PR DESCRIPTION
input-group-addon applies only on middle addons, theres no need to apply on first and last

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #2339 
| License         | MIT
