### PR TITLE
Move _events to the instance avoiding memory leaks

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -102,6 +102,10 @@
 
 	var Datepicker = function(element, options){
 		$.data(element, 'datepicker', this);
+    
+		this._events = [];
+		this._secondaryEvents = [];
+    
 		this._process_options(options);
 
 		this.dates = new DateArray();
@@ -321,8 +325,6 @@
 				o.defaultViewDate = UTCToday();
 			}
 		},
-		_events: [],
-		_secondaryEvents: [],
 		_applyEvents: function(evs){
 			for (var i=0, el, ch, ev; i < evs.length; i++){
 				el = evs[i][0];


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |Yes
| New feature?    | No
| BC breaks?      | No
| Related tickets | N/A
| License         | MIT


## What

The library `bootstrap-datepicker` uses its constructor's prototype to store the events attached to any newly initialized DatePicker component. It never cleans up the `_events` property, thus causing memory leaks even after you call `.datepicker('remove')`.

## Screencast

After testing my App for memory leaks, I found references to `DatePicker` when running heap snapshots, so I decided to check what was going on: tried to open the search view, open the inbox view, back to the search view, then to a lead page, back to the search view etc, and you can see that the `_events` keep growing:

![before](https://user-images.githubusercontent.com/7298695/41788649-af8d9352-7622-11e8-8330-7a1d09d14bd5.gif)

Checked my code, and `.datepicker('remove')` is correctly being called everywhere.

Also, after collecting the garbage and taking a heap snapshot, you can see that there are some references to DatePicker and that it allocates a good amount of bytes (because this `_events` property keeps a reference to the DOMElement, which keeps a reference of other DOMElements (eg `previousElementSibling` etc).

![image](https://user-images.githubusercontent.com/7298695/41788467-0b653ed8-7622-11e8-8997-74b60469ab16.png)

## Solution

After moving `_events` to the instance, there are no references to DatePicker anymore. Whenever the element is removed and `.datepicker('remove')` is called, the events associated are destroyed as well:

![image](https://user-images.githubusercontent.com/7298695/41789743-b710ee86-7626-11e8-8d61-1037368ce640.png)

## Tests

Used the Date Pickers across the app (snooze task, custom field date type, follow up, reporting etc), and everything worked as expected.