### PR TITLE
Update instructions for date-range

### DIFF
--- a/docs/markup.rst
+++ b/docs/markup.rst
@@ -51,7 +51,13 @@ Using the ``input-daterange`` construct with multiple child inputs will instanti
 .. figure:: _static/screenshots/markup_daterange.png
     :align: center
 
-Note that that ``input-daterange`` itself does not implement the ``datepicker`` methods. Methods should be directly called to the inputs. For example:
+In this case you'll need to instantiate the datepicker on the input's container, rather than on the inputs themselves. For example, in the markup above we could do:
+
+::
+
+    $('.input-daterange').datepicker();
+
+Note that that ``input-daterange`` itself does not implement the ``datepicker`` methods. Methods should still be directly called to the inputs. For example:
 
 ::
 


### PR DESCRIPTION
The instructions for initializing the date-range are easy to misinterpret. I think a more concrete example of the initializer will help in understanding how the construct should be used and will result in fewer issues on the matter:

EG:
- https://github.com/uxsolutions/bootstrap-datepicker/issues/2183#issuecomment-314618186
- https://github.com/uxsolutions/bootstrap-datepicker/issues/1815

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | #2183, #1815 
| License         | MIT
