### PR TITLE
Focused year is determined by UTC year

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -915,7 +915,7 @@
 			var view = this.picker.find(selector);
 			var startVal = Math.floor(year / factor) * factor;
 			var endVal = startVal + step * 9;
-			var focusedVal = Math.floor(this.viewDate.getFullYear() / step) * step;
+			var focusedVal = Math.floor(this.viewDate.getUTCFullYear() / step) * step;
 			var selected = $.map(this.dates, function(d){
 				return Math.floor(d.getUTCFullYear() / step) * step;
 			});


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

There was a bug where the focused value is set by local time year rather than UTC time year of viewDate, though viewDate is set as UTC time.
