### PR TITLE
rename "vovember" to correct "november"

### DIFF
--- a/js/locales/bootstrap-datepicker.no.js
+++ b/js/locales/bootstrap-datepicker.no.js
@@ -7,7 +7,7 @@
     days: ['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'],
     daysShort: ['søn', 'man', 'tir', 'ons', 'tor', 'fre', 'lør'],
     daysMin: ['sø', 'ma', 'ti', 'on', 'to', 'fr', 'lø'],
-    months: ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'vovember', 'desember'],
+    months: ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'],
     monthsShort: ['jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des'],
     today: 'i dag',
     monthsTitle: 'Måneder',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no|yes
| Related tickets | N/A
| License         | MIT
