### PR TITLE
Parsing dates without separator without format change

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -102,10 +102,10 @@
 
 	var Datepicker = function(element, options){
 		$.data(element, 'datepicker', this);
-    
+
 		this._events = [];
 		this._secondaryEvents = [];
-    
+
 		this._process_options(options);
 
 		this.dates = new DateArray();
@@ -1915,6 +1915,33 @@
 						if (!isNaN(_date))
 							date = _date;
 					}
+				}
+			}
+			else
+			{
+				// if iser writes date without separators 26012019
+				var startPosition = 0;
+				var rawDateString = "";
+				var fpart, v;
+
+				for (i = 0; i < parts.length; i++){
+					rawDateString = rawDateString + parts[i];
+				}
+
+				_date = new Date(date);
+				for (i = 0; i < fparts.length; i++){
+					fpart = fparts[i];
+					v = 0;
+					if( ( startPosition + fpart.length ) <= rawDateString.length ){
+						v = rawDateString.substring( startPosition, startPosition + fpart.length );
+						startPosition += fpart.length;
+					}
+					else if( fpart == "yy" || fpart == "yyyy" ) //in case year is not complete or missing put current year
+						v = (new Date()).getFullYear();
+
+					setters_map[ fpart ](_date, v);
+					if (!isNaN(_date))
+						date = _date;
 				}
 			}
 			return date;

--- a/tests/suites/formats.js
+++ b/tests/suites/formats.js
@@ -312,3 +312,21 @@ test('Assume nearby year - this century (+ 13 years, threshold = 30)', patch_dat
         .datepicker('setValue');
     equal(this.input.val(), '02/14/2023');
 }));
+
+test('Write date without separators - with Year', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('01262019')
+        .datepicker({format: 'mm/dd/yyyy'})
+        .datepicker('setValue');
+    equal(this.input.val(), '01/26/2019');
+}));
+
+test('Write date without separators - without Year', patch_date(function(Date){
+    Date.now = UTCDate(2012, 4, 31);
+    this.input
+        .val('0126')
+        .datepicker({format: 'mm/dd/yyyy'})
+        .datepicker('setValue');
+    equal(this.input.val(), '01/26/2012');
+}));


### PR DESCRIPTION
Possibility to write date without separators like "26012019" or "2601" instead of "26/01/2019" without format change.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | 
| License         | MIT
