### PR TITLE
introduce en-US locale

### DIFF
--- a/js/locales/bootstrap-datepicker.en-US.js
+++ b/js/locales/bootstrap-datepicker.en-US.js
@@ -1,0 +1,17 @@
+/**
+ * American English translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['en-US'] = {
+		days: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+		months: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+		monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+		today: "Today",
+		monthsTitle: "Months",
+		clear: "Clear",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | don't understand that.
| Related tickets |  no
| License         | MIT

differences to en-GB:
- `weekStart: 0` instead of `weekStart: 1`
- `format: dd/mm/yyyy` instead of `format: m/d/yyyy`

disclaimer: I'm not native us american - changes based on internet research.
