### PR TITLE
[CVE-2019-11358] Fix vuln jquery <3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/uxsolutions/bootstrap-datepicker.git"
   },
   "dependencies": {
-    "jquery": ">=1.7.1 <4.0.0"
+    "jquery": ">=3.4.0 <4.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.4",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | none
| License         | MIT

It fixes: https://nvd.nist.gov/vuln/detail/CVE-2019-11358