### PR TITLE
Align calendar to input element instead of group

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -687,7 +687,7 @@
 				if (itemZIndex !== 'auto' && Number(itemZIndex) !== 0) parentsZindex.push(Number(itemZIndex));
 			});
 			var zIndex = Math.max.apply(Math, parentsZindex) + this.o.zIndexOffset;
-			var offset = this.component ? this.component.parent().offset() : this.element.offset();
+			var offset = this.component ? this.component.parent().find('input').offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);
 			var left = offset.left - appendOffset.left;


### PR DESCRIPTION
When there is an input group with a prepend (like a field label) the calendar aligns to the prepend, with this small change it will align to the input field instead. I have not done extensive testing so it could be a bad idea, but it seems to work in every situation I throw at it.

This is a very minor change, I'm new to github I'm sorry if I've done this wrong.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
