### PR TITLE
Daterange doc fix

### DIFF
--- a/docs/markup.rst
+++ b/docs/markup.rst
@@ -55,7 +55,7 @@ Note that that ``input-daterange`` itself does not implement the ``datepicker`` 
 
 ::
 
-    $('.input-daterange input').each(function() {
+    $('.input-daterange').each(function() {
         $(this).datepicker('clearDates');
     });
 


### PR DESCRIPTION
Only the parent(s) should be selected.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT
