### PR TITLE
todayHighlight defaults table entry wrong

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -563,7 +563,7 @@ startView                    0 'days' (current month)
 templates
 title                        ''
 todayBtn                     false
-todayHighlight               true
+todayHighlight               false
 toggleActive                 false
 weekStart                    0 (Sunday)
 zIndexOffset                 10


### PR DESCRIPTION
todayHighlight is actually `false` by default; the defaults table incorrectly showed it as being `true` in conflict with the documentation higher up on the page.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT
