### PR TITLE
Orientation 'auto' doesn't calculate to correctly #2588

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -677,6 +677,7 @@
 				calendarHeight = this.picker.outerHeight(),
 				visualPadding = 10,
 				container = $(this.o.container),
+				fixedHeight = this.o.fixedHeight,
 				windowWidth = container.width(),
 				scrollTop = this.o.container === 'body' ? $(document).scrollTop() : container.scrollTop(),
 				appendOffset = container.offset();
@@ -734,7 +735,7 @@
 			var yorient = this.o.orientation.y,
 				top_overflow;
 			if (yorient === 'auto'){
-				top_overflow = -scrollTop + top - calendarHeight;
+				top_overflow = -scrollTop + top - (calendarHeight < 250 ? 250 : calendarHeight) - fixedHeight;
 				yorient = top_overflow < 0 ? 'bottom' : 'top';
 			}
 
@@ -1706,6 +1707,7 @@
 		daysOfWeekHighlighted: [],
 		datesDisabled: [],
 		endDate: Infinity,
+		fixedHeight: 0,
 		forceParse: true,
 		format: 'mm/dd/yyyy',
 		isInline: null,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    |yes
| Related tickets | fixes #2588 
| License         | MIT

I developed a solution for #2588. 

I changed line 738 and added a new attribute name is 'fixedHeight'. It defaults value 0, but the user/developer wants to add fixed height for top or bottom, they can use this attribute. Due to this attribute of datepicker orientation, the same way as the first created. This doesn't change the starting position for months, years, decades, centuries.

Maximum height value of 250. If the height change and decreases from 250, it return always 250. This is helpful for starting datepicker position and doesn't allow change according to the lowest height. If the height value higher than 250, it returns the highest value.

`top_overflow = -scrollTop + top - (calendarHeight < 250 ? 250 : calendarHeight) - fixedHeight;`

I share screens about my change.

First, fixedHeight equals 0. It's default value 0. This is like 'orientation' defaults values 'auto'. Calculation correct, but the user/developer doesn't change fixedHeight according to their header heights. For instance, this header height is 50px.
![image](https://user-images.githubusercontent.com/12368632/93026298-b59a0880-f60d-11ea-874e-e7bffefcb20d.png)

Second, I give 50, because of this example header height 50px.

![image](https://user-images.githubusercontent.com/12368632/93026366-2e996000-f60e-11ea-8308-9d1ab7df8c5e.png)

![image](https://user-images.githubusercontent.com/12368632/93026368-30fbba00-f60e-11ea-983f-bcb06f1325d7.png)


I hope, my issue and solution help us.

If you don't like this solution. Please can you give a trick or develop any solution for #2588.

Thanks, 
Greetings
