### PR TITLE
docs: Fix simple typo, millenium -> millennium

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -343,7 +343,7 @@ maxViewMode
 
 Number, String.  Default: 4, "centuries"
 
-Set a maximum limit for the view mode.  Accepts: 0 or "days" or "month", 1 or "months" or "year", 2 or "years" or "decade", 3 or "decades" or "century", and 4 or "centuries" or "millenium".
+Set a maximum limit for the view mode.  Accepts: 0 or "days" or "month", 1 or "months" or "year", 2 or "years" or "decade", 3 or "decades" or "century", and 4 or "centuries" or "millennium".
 Gives the ability to pick only a day, a month, a year or a decade.  The day is set to the 1st for "months", the month is set to January for "years", the year is set to the first year from the decade for "decades", and the year is set to the first from the millennium for "centuries".
 
 
@@ -352,7 +352,7 @@ minViewMode
 
 Number, String.  Default: 0, "days"
 
-Set a minimum limit for the view mode.  Accepts: 0 or "days" or "month", 1 or "months" or "year", 2 or "years" or "decade", 3 or "decades" or "century", and 4 or "centuries" or "millenium".
+Set a minimum limit for the view mode.  Accepts: 0 or "days" or "month", 1 or "months" or "year", 2 or "years" or "decade", 3 or "decades" or "century", and 4 or "centuries" or "millennium".
 Gives the ability to pick only a month, a year or a decade.  The day is set to the 1st for "months", and the month is set to January for "years", the year is set to the first year from the decade for "decades", and the year is set to the first from the millennium for "centuries".
 
 
@@ -416,7 +416,7 @@ startView
 
 Number, String.  Default: 0, "days"
 
-The view that the datepicker should show when it is opened.  Accepts: 0 or "days" or "month", 1 or "months" or "year", 2 or "years" or "decade", 3 or "decades" or "century", and 4 or "centuries" or "millenium".  Useful for date-of-birth datepickers.
+The view that the datepicker should show when it is opened.  Accepts: 0 or "days" or "month", 1 or "months" or "year", 2 or "years" or "decade", 3 or "decades" or "century", and 4 or "centuries" or "millennium".  Useful for date-of-birth datepickers.
 
 
 templates

--- a/tests/suites/component.js
+++ b/tests/suites/component.js
@@ -246,7 +246,7 @@ test('picker should render fine when `$.fn.show` and `$.fn.hide` are overridden'
     }
 }));
 
-test('Focused ceil for decade/century/millenium views', function(){
+test('Focused ceil for decade/century/millennium views', function(){
     var input = $('<input />')
       .appendTo('#qunit-fixture')
       .datepicker({

--- a/tests/suites/options.js
+++ b/tests/suites/options.js
@@ -1933,7 +1933,7 @@ test('Nav arrow html templates .prev click', function () {
     equal(target.text(), '2011');
 });
 
-test('Visibility of the prev and next arrows for year/decade/century/millenium views with startDate and endDate', function(){
+test('Visibility of the prev and next arrows for year/decade/century/millennium views with startDate and endDate', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')
                 .val('01/01/2015')
@@ -1973,7 +1973,7 @@ test('Visibility of the prev and next arrows for year/decade/century/millenium v
     ok(target.hasClass('disabled'), 'Next switcher is hidden');
 });
 
-test('Visibility of the prev arrow for month/year/decade/century/millenium views with startDate eq value', function(){
+test('Visibility of the prev arrow for month/year/decade/century/millennium views with startDate eq value', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')
                 .val('01/01/2014')
@@ -2009,7 +2009,7 @@ test('Visibility of the prev arrow for month/year/decade/century/millenium views
     ok(target.hasClass('disabled'), 'Prev switcher is hidden');
 });
 
-test('Visibility of the next arrow for month/year/decade/century/millenium views with endDate eq value', function(){
+test('Visibility of the next arrow for month/year/decade/century/millennium views with endDate eq value', function(){
     var input = $('<input />')
                 .appendTo('#qunit-fixture')
                 .val('31/12/1999')


### PR DESCRIPTION
There is a small typo in docs/options.rst.

Should read `millennium` rather than `millenium`.

