### PR TITLE
Allow to unselect disabled dates

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -425,7 +425,7 @@
 				[this.picker, '.prev, .next', {
 					click: $.proxy(this.navArrowsClick, this)
 				}],
-				[this.picker, '.day:not(.disabled)', {
+				[this.picker, '.day:not(.disabled:not(.active))', {
 					click: $.proxy(this.dayCellClick, this)
 				}],
 				[$(window), {


### PR DESCRIPTION
When we used datesDisabled option, and somehow user have selected one of disabled dates - its not possible for him to deselect them.
With this commit its fixed - he can deselect, but select option is disabled.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Related tickets |none
| License         | MIT
