### PR TITLE
setting date by typing trigger

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -816,7 +816,7 @@
 			}
 			else if (this.dates.length){
 				// setting date by typing
-				if (String(oldDates) !== String(this.dates) && fromArgs) {
+				if (String(oldDates) !== String(this.dates)) {
 					this._trigger('changeDate');
 					this.element.change();
 				}


### PR DESCRIPTION
I discovered a minor bug that prevented the change event from being fired when typing in the date. A conditional dead code.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Related tickets | none
| License         | Apache License 2.0
