### PR TITLE
Fix uneven behavior for maxViewMode and minViewMode

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -237,8 +237,8 @@
 
 			// Retrieve view index from any aliases
 			o.startView = this._resolveViewName(o.startView);
-			o.minViewMode = this._resolveViewName(o.minViewMode);
-			o.maxViewMode = this._resolveViewName(o.maxViewMode);
+			o.minViewMode = this._resolveViewName(parseInt(o.minViewMode));
+			o.maxViewMode = this._resolveViewName(parseInt(o.maxViewMode));
 
 			// Check view is between min and max
 			o.startView = Math.max(this.o.minViewMode, Math.min(this.o.maxViewMode, o.startView));


### PR DESCRIPTION
I noticed that maxViewMode and minViewMode have different behaviors based on the type of the variable that you passed it.

While maxViewMode works perfectly with a string, minView really wants an integer, probably it as to do with the checks that is does below, at line 1233.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| Related tickets | https://github.com/uxsolutions/bootstrap-datepicker/issues/2602
| License         | MIT
