### PR TITLE
Not require deprecated robloach/component-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,11 @@
     ],
     "type": "component",
     "require": {
-        "robloach/component-installer": "*",
         "components/bootstrap" : ">=2.0, <4.0",
         "components/jquery": ">=1.7.1, <4.0.0"
+    },
+    "suggest": {
+        "robloach/component-installer": "*"
     },
     "extra": {
         "component": {


### PR DESCRIPTION
The composer dependency robloach/component-installer is deprecated.
Moves it to suggested dependencies.
Fixes #2358.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #2358 
| License         | MIT
