### PR TITLE
Add Norwegian Nynorsk (nn) locale

### DIFF
--- a/js/locales/bootstrap-datepicker.nn.js
+++ b/js/locales/bootstrap-datepicker.nn.js
@@ -1,0 +1,17 @@
+/**
+ * Norwegian Nynorsk translation for bootstrap-datepicker
+ */
+;(function($){
+  $.fn.datepicker.dates['nn'] = {
+    days: ['søndag', 'måndag', 'tysdag', 'onsdag', 'torsdag', 'fredag', 'laurdag'],
+    daysShort: ['søn', 'mån', 'tys', 'ons', 'tor', 'fre', 'lau'],
+    daysMin: ['sø', 'må', 'ty', 'on', 'to', 'fr', 'la'],
+    months: ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'],
+    monthsShort: ['jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des'],
+    today: 'i dag',
+    monthsTitle: 'Månadar',
+    clear: 'Nullstill',
+    weekStart: 1,
+    format: 'dd.mm.yyyy'
+  };
+}(jQuery));


### PR DESCRIPTION
Adds a Norwegian **Nynorsk** (`nn`) locale. The plugin already ships `no` (Bokmål); this adds Norway's other official written standard (Nynorsk weekday/month names, "Månadar", etc.).

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian speaker.